### PR TITLE
Fix docs-testing SDK bugs: INVALID_ADDRESS mapping, error sanitization, and faucet()

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -32,8 +32,8 @@ If `npm install @fast/sdk` fails because the first npm release has not happened 
 
 1. Import `fast` from `@fast/sdk`.
 2. Create the client with `fast({ network: 'testnet' })` unless the user explicitly asked for mainnet.
-3. Call `await client.setup()` before any balance, send, signing, or token operation.
-4. Use the high-level methods first: `balance`, `send`, `sign`, `verify`, `tokens`, `tokenInfo`, `exportKeys`.
+3. Call `await client.setup()` before any balance, send, faucet, signing, or token operation.
+4. Use the high-level methods first: `balance`, `send`, `faucet`, `sign`, `verify`, `tokens`, `tokenInfo`, `exportKeys`.
 5. Use `submit` or `evmSign` only when the user explicitly needs low-level claim or certificate handling.
 
 ```ts
@@ -95,6 +95,15 @@ const tx = await client.send({
 - Returns `{ txHash, explorerUrl }`.
 - Validate the `fast1...` destination before calling `send()`.
 
+### Request testnet faucet tokens
+
+```ts
+const drip = await client.faucet();
+```
+
+- `faucet()` calls `proxy_faucetDrip` for the current wallet on `testnet`.
+- You can override the destination: `await client.faucet({ address: 'fast1...' })`.
+
 ### Sign and verify messages
 
 ```ts
@@ -138,7 +147,7 @@ const submitted = await client.submit({
   claim: {
     TokenTransfer: {
       token_id: [/* 32 bytes */],
-      amount: '1000000',
+      amount: 'de0b6b3a7640000',
       user_data: null,
     },
   },
@@ -150,6 +159,9 @@ const evm = await client.evmSign({
 ```
 
 - `submit()` sends a low-level claim and returns `{ txHash, certificate }`.
+- `submit()` `TokenTransfer.amount` is a hex string in raw base units (no `0x` prefix).
+- Native `SET` uses 18 decimals: `0xde0b6b3a7640000` = 1 SET, `0x56bc75e2d63100000` = 100 SET.
+- `SETUSDC` uses 6 decimals.
 - `evmSign()` derives an EVM-compatible signature from a Fast certificate.
 
 ## Errors

--- a/src/client.ts
+++ b/src/client.ts
@@ -53,6 +53,11 @@ type FastTokenInfoResponse = {
   requested_token_metadata?: Array<[number[], FastTokenMetadata | null]>;
 } | null;
 
+type RpcErrorPayload = {
+  message?: string;
+  code?: number;
+};
+
 function isNativeFastToken(token: string): boolean {
   const upper = token.toUpperCase();
   return upper === 'SET' || upper === 'FAST';
@@ -64,6 +69,92 @@ function tokenIdToHex(tokenId: number[] | Uint8Array): string {
 
 function stripHexPrefix(hex: string): string {
   return hex.startsWith('0x') || hex.startsWith('0X') ? hex.slice(2) : hex;
+}
+
+function parseRpcErrorPayload(rawMessage: string): RpcErrorPayload | null {
+  const prefix = 'RPC error:';
+  if (!rawMessage.startsWith(prefix)) {
+    return null;
+  }
+
+  const jsonPart = rawMessage.slice(prefix.length).trim();
+  if (!jsonPart) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(jsonPart) as RpcErrorPayload;
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function sanitizeProxyErrorMessage(rawMessage: string, fallback: string): string {
+  const rpcError = parseRpcErrorPayload(rawMessage);
+  let message = (rpcError?.message ?? rawMessage).replace(/\s+/g, ' ').trim();
+
+  for (const marker of ['panicked at', 'stack backtrace', 'validator/src/', 'RUST_BACKTRACE']) {
+    const idx = message.toLowerCase().indexOf(marker.toLowerCase());
+    if (idx >= 0) {
+      message = message.slice(0, idx).trim();
+    }
+  }
+
+  message = message
+    .replace(/(?:[A-Za-z0-9_.-]+\/)+[A-Za-z0-9_.-]+\.(?:rs|ts|js):\d+(?::\d+)?/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return message || fallback;
+}
+
+function isInsufficientBalanceMessage(message: string): boolean {
+  return /\binsufficient\b|InsufficientFunding/i.test(message);
+}
+
+function decodeFastAddressOrThrow(address: string): Uint8Array {
+  try {
+    const decoded = bech32m.decode(address, 90);
+    if (decoded.prefix !== 'fast') {
+      throw new Error(`invalid prefix: ${decoded.prefix}`);
+    }
+    const pubkey = new Uint8Array(bech32m.fromWords(decoded.words));
+    if (pubkey.length !== 32) {
+      throw new Error(`expected 32-byte pubkey, got ${pubkey.length}`);
+    }
+    return pubkey;
+  } catch {
+    throw new FastError('INVALID_ADDRESS', `Invalid Fast address: ${address}`, {
+      note: 'Use a valid fast1... bech32m address.',
+    });
+  }
+}
+
+function mapSubmissionError(
+  err: unknown,
+  opts: { insufficientNote: string; txFailedNote: string; txFailedFallbackMessage: string },
+): FastError {
+  if (err instanceof FastError) {
+    return err;
+  }
+
+  const rawMessage = err instanceof Error ? err.message : String(err);
+  const sanitizedMessage = sanitizeProxyErrorMessage(rawMessage, opts.txFailedFallbackMessage);
+
+  if (isInsufficientBalanceMessage(rawMessage) || isInsufficientBalanceMessage(sanitizedMessage)) {
+    return new FastError('INSUFFICIENT_BALANCE', 'Insufficient balance for this transfer.', {
+      note: opts.insufficientNote,
+    });
+  }
+
+  return new FastError('TX_FAILED', sanitizedMessage, {
+    note: opts.txFailedNote,
+  });
 }
 
 /**
@@ -258,13 +349,14 @@ export function fast(opts?: { network?: NetworkType }): FastClient {
       token?: string;
     }): Promise<{ txHash: string; explorerUrl: string }> {
       ensureSetup();
+      decodeFastAddressOrThrow(params.to);
 
       // Resolve token ID and decimals
       let tokenId: Uint8Array = SET_TOKEN_ID;
       let decimals = FAST_DECIMALS;
 
       if (params.token && !isNativeFastToken(params.token)) {
-        const accountInfo = await fetchAccountInfo(addressToPubkey(_address!));
+        const accountInfo = await fetchAccountInfo(decodeFastAddressOrThrow(_address!));
 
         if (HEX_TOKEN_PATTERN.test(params.token)) {
           tokenId = hexToTokenId(params.token);
@@ -300,17 +392,38 @@ export function fast(opts?: { network?: NetworkType }): FastClient {
           explorerUrl: `${EXPLORER_BASE}/${result.txHash}`,
         };
       } catch (err: unknown) {
-        if (err instanceof FastError) throw err;
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes('InsufficientFunding') || msg.includes('insufficient')) {
-          throw new FastError('INSUFFICIENT_BALANCE', msg, {
-            note: 'Fund your Fast wallet with SET or SETUSDC, then retry.',
-          });
-        }
-        throw new FastError('TX_FAILED', msg, {
-          note: 'Wait 5 seconds, then retry the send.',
+        throw mapSubmissionError(err, {
+          insufficientNote: 'Fund your Fast wallet with SET or SETUSDC, then retry.',
+          txFailedNote: 'Wait 5 seconds, then retry the send.',
+          txFailedFallbackMessage: 'Transaction submission failed.',
         });
       }
+    },
+
+    async faucet(opts?: { address?: string }): Promise<{ address: string }> {
+      ensureSetup();
+
+      if (network !== 'testnet') {
+        throw new FastError('UNSUPPORTED_OPERATION', 'Faucet is only available on testnet.', {
+          note: 'Switch to fast({ network: "testnet" }) or fund this address externally.',
+        });
+      }
+
+      const targetAddress = opts?.address ?? _address!;
+      decodeFastAddressOrThrow(targetAddress);
+
+      try {
+        await rpcCall(rpcUrl, 'proxy_faucetDrip', [targetAddress]);
+      } catch (err: unknown) {
+        if (err instanceof FastError) throw err;
+        const rawMessage = err instanceof Error ? err.message : String(err);
+        const safeMessage = sanitizeProxyErrorMessage(rawMessage, 'Faucet request failed.');
+        throw new FastError('TX_FAILED', safeMessage, {
+          note: 'Retry in a few seconds. The faucet may be rate-limited.',
+        });
+      }
+
+      return { address: targetAddress };
     },
 
     async submit(params: {
@@ -318,8 +431,8 @@ export function fast(opts?: { network?: NetworkType }): FastClient {
       claim: Record<string, unknown>;
     }): Promise<{ txHash: string; certificate: unknown }> {
       ensureSetup();
-      const senderPubkey = addressToPubkey(_address!);
-      const recipientPubkey = addressToPubkey(params.recipient);
+      const senderPubkey = decodeFastAddressOrThrow(_address!);
+      const recipientPubkey = decodeFastAddressOrThrow(params.recipient);
 
       try {
         return await withKey<{ txHash: string; certificate: unknown }>(
@@ -358,15 +471,10 @@ export function fast(opts?: { network?: NetworkType }): FastClient {
           },
         );
       } catch (err: unknown) {
-        if (err instanceof FastError) throw err;
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes('InsufficientFunding') || msg.includes('insufficient')) {
-          throw new FastError('INSUFFICIENT_BALANCE', msg, {
-            note: 'Fund your Fast wallet with SET or SETUSDC, then retry.',
-          });
-        }
-        throw new FastError('TX_FAILED', msg, {
-          note: 'Wait 5 seconds, then retry.',
+        throw mapSubmissionError(err, {
+          insufficientNote: 'Fund your Fast wallet with SET or SETUSDC, then retry.',
+          txFailedNote: 'Wait 5 seconds, then retry.',
+          txFailedFallbackMessage: 'Transaction submission failed.',
         });
       }
     },

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -15,7 +15,7 @@ function toJSON(data: unknown): string {
 export async function rpcCall(
   url: string,
   method: string,
-  params: Record<string, unknown>,
+  params: unknown,
   timeoutMs = 15_000,
 ): Promise<unknown> {
   const controller = new AbortController();

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,8 @@ export interface FastClient {
   balance(opts?: { token?: string }): Promise<{ amount: string; token: string }>;
   /** Send tokens to an address. Defaults to native SET; custom tokens can be passed by held symbol or hex token ID. */
   send(params: { to: string; amount: string; token?: string }): Promise<{ txHash: string; explorerUrl: string }>;
+  /** Request testnet faucet funds for the current wallet or an explicit address */
+  faucet(opts?: { address?: string }): Promise<{ address: string }>;
   /** Sign a message with the wallet's Ed25519 key */
   sign(params: { message: string | Uint8Array }): Promise<{ signature: string; address: string }>;
   /** Verify an Ed25519 signature against a fast1... address */

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -53,6 +53,7 @@ describe('fast() factory', () => {
       'setup',
       'balance',
       'send',
+      'faucet',
       'submit',
       'evmSign',
       'sign',
@@ -362,6 +363,33 @@ describe('custom token resolution', () => {
     assert.equal(tx.claim?.TokenTransfer?.amount, '16e360');
   });
 
+  it('send() throws INVALID_ADDRESS for malformed recipient before RPC submit', async () => {
+    let rpcCalled = false;
+
+    globalThis.fetch = (async (_url: string | URL | Request, _init?: RequestInit) => {
+      rpcCalled = true;
+      throw new Error('RPC should not be called for invalid destination address');
+    }) as typeof fetch;
+
+    const f = fast({ network: 'mainnet' });
+    await f.setup();
+
+    await assert.rejects(
+      () => f.send({
+        to: 'fast1invalid_address_here',
+        amount: '1',
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof FastError);
+        assert.equal(error.code, 'INVALID_ADDRESS');
+        assert.match(error.message, /Invalid Fast address/i);
+        return true;
+      },
+    );
+
+    assert.equal(rpcCalled, false);
+  });
+
   it('send() maps Fast insufficient funding errors to INSUFFICIENT_BALANCE', async () => {
     globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
       const bodyText = typeof init?.body === 'string' ? init.body : '';
@@ -382,7 +410,7 @@ describe('custom token resolution', () => {
             id: 1,
             error: {
               code: -32000,
-              message: 'quorum not reached: SubmitError(FastSet(InsufficientFunding))',
+              message: 'Execution error: panicked at validator/src/ledger/validator.rs:97:8: quorum not reached: SubmitError(FastSet(InsufficientFunding))',
             },
           }),
           {
@@ -407,6 +435,7 @@ describe('custom token resolution', () => {
       (error: unknown) => {
         assert.ok(error instanceof FastError);
         assert.equal(error.code, 'INSUFFICIENT_BALANCE');
+        assert.doesNotMatch(error.message, /validator\/src|panicked at/i);
         return true;
       },
     );
@@ -474,5 +503,44 @@ describe('custom token resolution', () => {
     assert.equal(info.decimals, 6);
     assert.equal(info.address, '0x1e744900021182b293538bb6685b77df095e351364d550021614ce90c8ab9e0a');
     assert.equal(info.totalSupply, '12345000000');
+  });
+});
+
+describe('faucet()', () => {
+  it('requests a testnet faucet drip for the current wallet', async () => {
+    let faucetParams: unknown = null;
+
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      const bodyText = typeof init?.body === 'string' ? init.body : '';
+      const parsed = JSON.parse(bodyText) as { method: string; params: unknown };
+
+      if (parsed.method === 'proxy_faucetDrip') {
+        faucetParams = parsed.params;
+        return rpcResult({ ok: true });
+      }
+
+      throw new Error(`Unexpected RPC method: ${parsed.method}`);
+    }) as typeof fetch;
+
+    const f = fast({ network: 'testnet' });
+    const { address } = await f.setup();
+    const result = await f.faucet();
+
+    assert.equal(result.address, address);
+    assert.deepEqual(faucetParams, [address]);
+  });
+
+  it('throws on mainnet', async () => {
+    const f = fast({ network: 'mainnet' });
+    await f.setup();
+
+    await assert.rejects(
+      () => f.faucet(),
+      (error: unknown) => {
+        assert.ok(error instanceof FastError);
+        assert.equal(error.code, 'UNSUPPORTED_OPERATION');
+        return true;
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary
- validate fast1 recipient addresses before submit and throw INVALID_ADDRESS
- sanitize proxy/Rust panic messages before surfacing errors, and keep insufficient-balance responses user-safe
- add high-level client.faucet() wrapper for proxy_faucetDrip on testnet
- wire faucet() into FastClient types and allow positional RPC params arrays
- update SKILL.md low-level amount docs to correctly reflect 18-decimal SET examples

## Tests
- npm test
- npm run build