### PR TITLE
chore: release 0.1.1 metadata update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Pi2Labs
+Copyright (c) 2026 Fast.xyz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastxyz/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Fast SDK — wallet management, payments, and RPC",
   "keywords": [
     "fast",
@@ -32,7 +32,7 @@
   "engines": {
     "node": ">=20"
   },
-  "author": "Pi2Labs",
+  "author": "Fast.xyz",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- bump @fastxyz/sdk to 0.1.1
- update the package author from Pi2Labs to Fast.xyz
- update the LICENSE copyright holder from Pi2Labs to Fast.xyz

## Verification
- npm run build
- npm test
- npm run pack:dry-run
- npm run pack:smoke