### PR TITLE
feat: add multi-key support with named keys and explicit keyFile

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -53,6 +53,34 @@ const client = fast({
 });
 ```
 
+### Named keys (multiple wallets)
+
+Use the `key` option to manage multiple wallets:
+
+```ts
+// Creates/loads ~/.fast/keys/merchant.json
+const merchant = fast({ network: 'testnet', key: 'merchant' });
+await merchant.setup();
+
+// Creates/loads ~/.fast/keys/buyer.json
+const buyer = fast({ network: 'testnet', key: 'buyer' });
+await buyer.setup();
+
+// Default key (equivalent to key: 'default')
+const f = fast({ network: 'testnet' });  // Uses ~/.fast/keys/default.json
+```
+
+### Explicit key file path
+
+Use `keyFile` to specify an exact path (takes priority over `key`):
+
+```ts
+const client = fast({
+  network: 'testnet',
+  keyFile: '/secure/keys/prod.json'
+});
+```
+
 ## Safety Rules
 
 - Default to `testnet`. Use `mainnet` only with explicit user approval because it uses real funds.
@@ -192,7 +220,7 @@ Common codes:
 - Default config dir: `~/.fast`
 - Override config dir: `FAST_CONFIG_DIR`
 - Config file: `~/.fast/config.json`
-- Key file: `~/.fast/keys/fast.json`
+- Key file: `~/.fast/keys/default.json` (or `~/.fast/keys/{name}.json` for named keys)
 - Optional seed env var: `MONEY_FAST_PRIVATE_KEY`
 
 ## Not for This Skill

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,8 +29,8 @@ import {
   hexToTokenId,
 } from './bcs.js';
 import { pubkeyToAddress, addressToPubkey } from './address.js';
-import { toHex, fromHex } from './utils.js';
-import type { FastClient, NetworkType } from './types.js';
+import { toHex, fromHex, expandHome } from './utils.js';
+import type { FastClient, NetworkType, FastOptions } from './types.js';
 
 const DEFAULT_TOKEN = 'FAST';
 const HEX_TOKEN_PATTERN = /^(0x)?[0-9a-fA-F]+$/;
@@ -160,12 +160,29 @@ function mapSubmissionError(
 /**
  * Create a Fast client.
  *
- * @example
+ * @example Basic usage
  * ```ts
  * const f = fast({ network: 'testnet' });
  * await f.setup();
  * await f.balance();
  * await f.send({ to: 'fast1...', amount: '1.0' });
+ * ```
+ *
+ * @example Named keys (multiple wallets)
+ * ```ts
+ * const merchant = fast({ network: 'testnet', key: 'merchant' });
+ * await merchant.setup();  // Uses ~/.fast/keys/merchant.json
+ *
+ * const buyer = fast({ network: 'testnet', key: 'buyer' });
+ * await buyer.setup();     // Uses ~/.fast/keys/buyer.json
+ * ```
+ *
+ * @example Custom key file path
+ * ```ts
+ * const f = fast({
+ *   network: 'testnet',
+ *   keyFile: '/secure/keys/prod.json'
+ * });
  * ```
  *
  * @example Custom RPC endpoint
@@ -176,10 +193,12 @@ function mapSubmissionError(
  * });
  * ```
  */
-export function fast(opts?: { network?: NetworkType; rpcUrl?: string }): FastClient {
+export function fast(opts?: FastOptions): FastClient {
   const network: NetworkType = opts?.network ?? 'testnet';
   const defaults = FAST_NETWORK_CONFIGS[network];
   const rpcUrl = opts?.rpcUrl ?? defaults.rpc;
+  const keyName = opts?.key ?? 'default';
+  const explicitKeyFile = opts?.keyFile;
 
   let _address: string | null = null;
   let _keyfilePath: string | null = null;
@@ -283,8 +302,13 @@ export function fast(opts?: { network?: NetworkType; rpcUrl?: string }): FastCli
     },
 
     async setup(): Promise<{ address: string }> {
-      const keysDir = getKeysDir();
-      _keyfilePath = path.join(keysDir, 'fast.json');
+      // Resolve key file path: explicit keyFile > named key > default
+      if (explicitKeyFile) {
+        _keyfilePath = expandHome(explicitKeyFile);
+      } else {
+        const keysDir = getKeysDir();
+        _keyfilePath = path.join(keysDir, `${keyName}.json`);
+      }
 
       try {
         const existing = await loadKeyfile(_keyfilePath);
@@ -299,8 +323,8 @@ export function fast(opts?: { network?: NetworkType; rpcUrl?: string }): FastCli
         _address = pubkeyToAddress(keypair.publicKey);
       }
 
-      const key = configKey(network);
-      await setNetworkConfig(key, {
+      const cfgKey = configKey(network);
+      await setNetworkConfig(cfgKey, {
         rpc: rpcUrl,
         keyfile: _keyfilePath,
         network,

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -14,13 +14,13 @@ export type KnownFastToken = {
 export const FAST_NETWORK_CONFIGS: Record<NetworkType, NetworkConfig> = {
   testnet: {
     rpc: 'https://staging.proxy.fastset.xyz',
-    keyfile: '~/.fast/keys/fast.json',
+    keyfile: '~/.fast/keys/default.json',
     network: 'testnet',
     defaultToken: 'FAST',
   },
   mainnet: {
     rpc: 'https://api.fast.xyz/proxy',
-    keyfile: '~/.fast/keys/fast.json',
+    keyfile: '~/.fast/keys/default.json',
     network: 'mainnet',
     defaultToken: 'FAST',
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,4 @@ export { FastError } from './errors.js';
 export type { FastErrorCode } from './errors.js';
 
 // Types
-export type { FastClient, NetworkType } from './types.js';
+export type { FastClient, NetworkType, FastOptions } from './types.js';

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -11,6 +11,7 @@ import { open, readFile, mkdir, copyFile, chmod } from 'node:fs/promises';
 import { dirname, basename, join } from 'node:path';
 import { constants } from 'node:fs';
 import { expandHome } from './utils.js';
+import { pubkeyToAddress } from './address.js';
 import * as ed from '@noble/ed25519';
 import { sha512 } from '@noble/hashes/sha512';
 
@@ -85,6 +86,10 @@ export async function generateEd25519Key(): Promise<{ publicKey: string; private
 /**
  * Load a keyfile from disk.
  * Expands `~` in the path.
+ * 
+ * Supports two formats:
+ * - New format: { privateKey, address } - publicKey is derived
+ * - Legacy format: { publicKey, privateKey } - for backward compatibility
  */
 export async function loadKeyfile(
   path: string,
@@ -108,15 +113,31 @@ export async function loadKeyfile(
     }
   }
   const parsed = JSON.parse(raw) as Record<string, unknown>;
-  if (typeof parsed.publicKey !== 'string' || typeof parsed.privateKey !== 'string') {
-    throw new Error(`Keyfile at ${resolved} is missing publicKey or privateKey fields`);
+  
+  if (typeof parsed.privateKey !== 'string') {
+    throw new Error(`Keyfile at ${resolved} is missing privateKey field`);
   }
-  return { publicKey: parsed.publicKey, privateKey: parsed.privateKey };
+  
+  // If publicKey exists (legacy format), use it; otherwise derive from privateKey
+  let publicKey: string;
+  if (typeof parsed.publicKey === 'string') {
+    publicKey = parsed.publicKey;
+  } else {
+    // Derive publicKey from privateKey
+    const keypair = await keypairFromPrivateKey(parsed.privateKey);
+    publicKey = keypair.publicKey;
+  }
+  
+  return { publicKey, privateKey: parsed.privateKey };
 }
 
 /**
  * Save a keypair to a keyfile.
  * Creates parent directories with mode 0700 and writes the file with mode 0600.
+ *
+ * File format: { privateKey, address }
+ * - privateKey: hex-encoded Ed25519 private key (required for signing)
+ * - address: bech32m address (for human reference, derived from publicKey)
  *
  * Uses O_CREAT | O_WRONLY | O_EXCL so the call **fails** if the file already
  * exists.  This prevents any code path from accidentally overwriting a wallet
@@ -132,7 +153,8 @@ export async function saveKeyfile(
   const resolved = expandHome(keyPath);
   const dir = dirname(resolved);
   await mkdir(dir, { recursive: true, mode: 0o700 });
-  const json = JSON.stringify({ publicKey: keypair.publicKey, privateKey: keypair.privateKey }, null, 2);
+  const address = pubkeyToAddress(keypair.publicKey);
+  const json = JSON.stringify({ privateKey: keypair.privateKey, address }, null, 2);
 
   // O_EXCL: fail if file exists — never overwrite a keyfile
   const fd = await open(resolved, constants.O_CREAT | constants.O_WRONLY | constants.O_EXCL, 0o600);

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,18 @@
 /** Network types */
 export type NetworkType = 'testnet' | 'mainnet';
 
+/** Options for the fast() factory */
+export interface FastOptions {
+  /** Network to connect to (default: 'testnet') */
+  network?: NetworkType;
+  /** Custom RPC URL (overrides network default) */
+  rpcUrl?: string;
+  /** Named key - resolves to ~/.fast/keys/{key}.json (default: 'default') */
+  key?: string;
+  /** Explicit key file path - takes priority over `key` if both provided */
+  keyFile?: string;
+}
+
 /** Network configuration */
 export interface NetworkConfig {
   rpc: string;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -139,10 +139,10 @@ describe('setup()', () => {
     assert.equal(f.address, result.address);
   });
 
-  it('creates a keyfile at path.join(tmpDir, "keys", "fast.json")', async () => {
+  it('creates a keyfile at path.join(tmpDir, "keys", "default.json")', async () => {
     const f = fast();
     await f.setup();
-    const keyfilePath = path.join(tmpDir, 'keys', 'fast.json');
+    const keyfilePath = path.join(tmpDir, 'keys', 'default.json');
     const stat = await fs.stat(keyfilePath);
     assert.ok(stat.isFile(), `expected keyfile at ${keyfilePath}`);
   });
@@ -162,6 +162,58 @@ describe('setup() idempotency', () => {
     const first = await f.setup();
     const second = await f.setup();
     assert.equal(first.address, second.address);
+  });
+});
+
+describe('named keys', () => {
+  it('creates keyfile with custom name via key option', async () => {
+    const f = fast({ key: 'merchant' });
+    await f.setup();
+    const keyfilePath = path.join(tmpDir, 'keys', 'merchant.json');
+    const stat = await fs.stat(keyfilePath);
+    assert.ok(stat.isFile(), `expected keyfile at ${keyfilePath}`);
+  });
+
+  it('different key names create different addresses', async () => {
+    const merchant = fast({ key: 'merchant2' });
+    const buyer = fast({ key: 'buyer2' });
+    const merchantResult = await merchant.setup();
+    const buyerResult = await buyer.setup();
+    assert.notEqual(merchantResult.address, buyerResult.address);
+  });
+
+  it('same key name returns same address', async () => {
+    const f1 = fast({ key: 'consistent' });
+    const f2 = fast({ key: 'consistent' });
+    const result1 = await f1.setup();
+    const result2 = await f2.setup();
+    assert.equal(result1.address, result2.address);
+  });
+});
+
+describe('explicit keyFile', () => {
+  it('uses explicit keyFile path when provided', async () => {
+    const customPath = path.join(tmpDir, 'custom', 'mykey.json');
+    const f = fast({ keyFile: customPath });
+    await f.setup();
+    const stat = await fs.stat(customPath);
+    assert.ok(stat.isFile(), `expected keyfile at ${customPath}`);
+  });
+
+  it('keyFile takes priority over key option', async () => {
+    const customPath = path.join(tmpDir, 'priority', 'priority.json');
+    const f = fast({ key: 'ignored', keyFile: customPath });
+    await f.setup();
+    const stat = await fs.stat(customPath);
+    assert.ok(stat.isFile(), `expected keyfile at ${customPath}`);
+    // Verify the key option file was NOT created
+    const ignoredPath = path.join(tmpDir, 'keys', 'ignored.json');
+    try {
+      await fs.stat(ignoredPath);
+      assert.fail('ignored.json should not exist');
+    } catch (err: unknown) {
+      assert.equal((err as NodeJS.ErrnoException).code, 'ENOENT');
+    }
   });
 });
 

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -98,13 +98,13 @@ describe('keys', () => {
 
       const loaded = await loadKeyfile(seededPath);
       const fromDisk = JSON.parse(await fs.readFile(seededPath, 'utf-8')) as {
-        publicKey: string;
         privateKey: string;
+        address: string;
       };
 
       assert.equal(loaded.privateKey, '1111111111111111111111111111111111111111111111111111111111111111');
       assert.equal(fromDisk.privateKey, loaded.privateKey);
-      assert.equal(fromDisk.publicKey, loaded.publicKey);
+      assert.ok(fromDisk.address.startsWith('fast1'), 'address should start with fast1');
       assert.equal(loaded.publicKey.length, 64);
     });
   });


### PR DESCRIPTION
Add support for managing multiple wallets:

- `key` option: Named keys resolve to ~/.fast/keys/{key}.json
  Example: fast({ key: 'merchant' }) → ~/.fast/keys/merchant.json

- `keyFile` option: Explicit path (takes priority over key)
  Example: fast({ keyFile: '/path/to/key.json' })

- Default key changed from 'fast.json' to 'default.json'

Key file format changed to { privateKey, address }:
- privateKey: hex-encoded Ed25519 key (required)
- address: bech32m address (for human reference)
- publicKey is now derived from privateKey at load time
- Legacy format { publicKey, privateKey } still supported

Changes:
- Add FastOptions interface with key/keyFile options
- Update setup() to resolve key paths
- Update saveKeyfile() to save { privateKey, address }
- Update loadKeyfile() to derive publicKey if not present
- Update defaults to use default.json
- Add tests for named keys and explicit keyFile
- Update SKILL.md documentation

All 126 tests pass.