### PR TITLE
refactor: use networks.json and tokens.json for configuration

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -219,9 +219,36 @@ Common codes:
 
 - Default config dir: `~/.fast`
 - Override config dir: `FAST_CONFIG_DIR`
-- Config file: `~/.fast/config.json`
 - Key file: `~/.fast/keys/default.json` (or `~/.fast/keys/{name}.json` for named keys)
 - Optional seed env var: `MONEY_FAST_PRIVATE_KEY`
+
+### Configuration Files (Optional)
+
+Network and token configuration is loaded from JSON files. User overrides in `~/.fast/` take precedence over bundled defaults:
+
+- `~/.fast/networks.json` — Custom networks
+- `~/.fast/tokens.json` — Custom tokens
+
+Example `~/.fast/networks.json`:
+```json
+{
+  "custom-net": {
+    "rpc": "https://custom.rpc.url/proxy",
+    "explorer": "https://custom.explorer.url"
+  }
+}
+```
+
+Example `~/.fast/tokens.json`:
+```json
+{
+  "MYTOKEN": {
+    "symbol": "MYTOKEN",
+    "tokenId": "0x1234...",
+    "decimals": 18
+  }
+}
+```
 
 ## Not for This Skill
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,15 +16,14 @@ import {
   signEd25519,
   verifyEd25519,
 } from './keys.js';
-import { getKeysDir, setNetworkConfig } from './config.js';
-import { FAST_NETWORK_CONFIGS, configKey, resolveKnownFastToken } from './defaults.js';
+import { getKeysDir } from './config.js';
+import { getNetworkInfo, resolveKnownFastToken, getExplorerUrl, FAST_NETWORK_CONFIGS } from './defaults.js';
 import { rpcCall } from './rpc.js';
 import {
   TransactionBcs,
   hashTransaction,
   FAST_DECIMALS,
   FAST_TOKEN_ID,
-  EXPLORER_BASE,
   tokenIdEquals,
   hexToTokenId,
 } from './bcs.js';
@@ -195,10 +194,12 @@ function mapSubmissionError(
  */
 export function fast(opts?: FastOptions): FastClient {
   const network: NetworkType = opts?.network ?? 'testnet';
-  const defaults = FAST_NETWORK_CONFIGS[network];
-  const rpcUrl = opts?.rpcUrl ?? defaults.rpc;
+  // Use fallback for sync initialization; setup() can override with loaded config
+  const fallbackRpc = FAST_NETWORK_CONFIGS[network]?.rpc ?? 'https://staging.proxy.fastset.xyz';
+  let rpcUrl = opts?.rpcUrl ?? fallbackRpc;
   const keyName = opts?.key ?? 'default';
   const explicitKeyFile = opts?.keyFile;
+  let _explorerUrl: string | null = null;
 
   let _address: string | null = null;
   let _keyfilePath: string | null = null;
@@ -277,7 +278,7 @@ export function fast(opts?: FastOptions): FastClient {
       };
     }
 
-    const known = resolveKnownFastToken(token);
+    const known = await resolveKnownFastToken(token);
     if (known) {
       const tokenId = hexToTokenId(known.tokenId);
       const metadata = await fetchTokenMetadata([tokenId]);
@@ -302,6 +303,15 @@ export function fast(opts?: FastOptions): FastClient {
     },
 
     async setup(): Promise<{ address: string }> {
+      // Load network config from JSON files (if not overridden by user)
+      if (!opts?.rpcUrl) {
+        const networkInfo = await getNetworkInfo(network);
+        if (networkInfo?.rpc) {
+          rpcUrl = networkInfo.rpc;
+        }
+      }
+      _explorerUrl = await getExplorerUrl(network);
+
       // Resolve key file path: explicit keyFile > named key > default
       if (explicitKeyFile) {
         _keyfilePath = expandHome(explicitKeyFile);
@@ -322,14 +332,6 @@ export function fast(opts?: FastOptions): FastClient {
         await saveKeyfile(_keyfilePath, keypair);
         _address = pubkeyToAddress(keypair.publicKey);
       }
-
-      const cfgKey = configKey(network);
-      await setNetworkConfig(cfgKey, {
-        rpc: rpcUrl,
-        keyfile: _keyfilePath,
-        network,
-        defaultToken: DEFAULT_TOKEN,
-      });
 
       return { address: _address };
     },
@@ -425,9 +427,10 @@ export function fast(opts?: FastOptions): FastClient {
             },
           },
         });
+        const baseUrl = _explorerUrl ?? 'https://explorer.fast.xyz';
         return {
           txHash: result.txHash,
-          explorerUrl: `${EXPLORER_BASE}/${result.txHash}`,
+          explorerUrl: `${baseUrl}/txs/${result.txHash}`,
         };
       } catch (err: unknown) {
         throw mapSubmissionError(err, {
@@ -652,7 +655,7 @@ export function fast(opts?: FastOptions): FastClient {
       if (HEX_TOKEN_PATTERN.test(tok)) {
         tokenIdBytes = hexToTokenId(tok);
       } else {
-        const known = resolveKnownFastToken(tok);
+        const known = await resolveKnownFastToken(tok);
         if (known) {
           tokenIdBytes = hexToTokenId(known.tokenId);
         } else {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,12 @@
-import fs from 'node:fs/promises';
+/**
+ * config.ts — Fast SDK configuration directory utilities
+ *
+ * Provides path helpers for the Fast config directory (~/.fast/).
+ * Network and token configuration is loaded from JSON files in defaults.ts.
+ */
+
 import os from 'node:os';
 import path from 'node:path';
-import type { FastConfig, NetworkConfig } from './types.js';
 
 /**
  * Returns the expanded path to the config directory (~/.fast/ by default).
@@ -22,81 +27,4 @@ export function getConfigDir(): string {
  */
 export function getKeysDir(): string {
   return path.join(getConfigDir(), 'keys');
-}
-
-/**
- * Returns the full path to the config file.
- */
-function getConfigPath(): string {
-  return path.join(getConfigDir(), 'config.json');
-}
-
-/**
- * Load the config from ~/.fast/config.json.
- * Returns { networks: {} } if the file does not exist.
- */
-export async function loadConfig(): Promise<FastConfig> {
-  const configPath = getConfigPath();
-  try {
-    const raw = await fs.readFile(configPath, 'utf-8');
-    const parsed = JSON.parse(raw) as FastConfig;
-    if (!parsed.networks || typeof parsed.networks !== 'object') {
-      throw new Error(`Invalid config at ${configPath}: missing "networks" object`);
-    }
-    return parsed;
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { networks: {} };
-    }
-    throw new Error(
-      `Failed to load config from ${configPath}: ${(err as Error).message}`
-    );
-  }
-}
-
-/**
- * Save the config to ~/.fast/config.json.
- * Creates ~/.fast/ with mode 0700 if needed.
- * Writes the file with mode 0600.
- */
-export async function saveConfig(config: FastConfig): Promise<void> {
-  const configDir = getConfigDir();
-  const configPath = getConfigPath();
-
-  try {
-    await fs.mkdir(configDir, { recursive: true, mode: 0o700 });
-  } catch (err: unknown) {
-    throw new Error(
-      `Failed to create config directory ${configDir}: ${(err as Error).message}`
-    );
-  }
-
-  const content = JSON.stringify(config, null, 2);
-  const tmpPath = `${configPath}.tmp.${process.pid}`;
-  try {
-    await fs.writeFile(tmpPath, content, { encoding: 'utf-8', mode: 0o600 });
-    await fs.rename(tmpPath, configPath);
-  } catch (err: unknown) {
-    try { await fs.unlink(tmpPath); } catch { /* ignore */ }
-    throw new Error(
-      `Failed to write config to ${configPath}: ${(err as Error).message}`
-    );
-  }
-}
-
-/**
- * Get the config for a specific network, or null if not configured.
- */
-export async function getNetworkConfig(network: string): Promise<NetworkConfig | null> {
-  const config = await loadConfig();
-  return config.networks[network] ?? null;
-}
-
-/**
- * Add or update a network's config and persist it.
- */
-export async function setNetworkConfig(network: string, networkConfig: NetworkConfig): Promise<void> {
-  const config = await loadConfig();
-  config.networks[network] = networkConfig;
-  await saveConfig(config);
 }

--- a/src/data/networks.json
+++ b/src/data/networks.json
@@ -1,0 +1,10 @@
+{
+  "testnet": {
+    "rpc": "https://staging.proxy.fastset.xyz",
+    "explorer": "https://explorer.fast.xyz"
+  },
+  "mainnet": {
+    "rpc": "https://api.fast.xyz/proxy",
+    "explorer": "https://explorer.fast.xyz"
+  }
+}

--- a/src/data/tokens.json
+++ b/src/data/tokens.json
@@ -1,0 +1,12 @@
+{
+  "FAST": {
+    "symbol": "FAST",
+    "tokenId": "native",
+    "decimals": 9
+  },
+  "fastUSDC": {
+    "symbol": "fastUSDC",
+    "tokenId": "0xb4cf1b9e227bb6a21b959338895dfb39b8d2a96dfa1ce5dd633561c193124cb5",
+    "decimals": 6
+  }
+}

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,8 +1,29 @@
 /**
  * defaults.ts — Default Fast configuration
+ *
+ * Priority order (highest to lowest):
+ * 1. User overrides: ~/.fast/networks.json, ~/.fast/tokens.json
+ * 2. Bundled JSON (imported as modules)
+ * 3. Hardcoded fallbacks (this file)
  */
 
-import type { NetworkType, NetworkConfig } from './types.js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { NetworkType } from './types.js';
+import { getConfigDir } from './config.js';
+
+// Import bundled JSON directly (resolveJsonModule: true in tsconfig)
+import bundledNetworks from './data/networks.json' with { type: 'json' };
+import bundledTokens from './data/tokens.json' with { type: 'json' };
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * Types
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+export type NetworkInfo = {
+  rpc: string;
+  explorer: string;
+};
 
 export type KnownFastToken = {
   symbol: string;
@@ -10,26 +31,27 @@ export type KnownFastToken = {
   decimals: number;
 };
 
-/** Default Fast configs */
-export const FAST_NETWORK_CONFIGS: Record<NetworkType, NetworkConfig> = {
+/* ─────────────────────────────────────────────────────────────────────────────
+ * Hardcoded Fallbacks (used if JSON files fail to load)
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+const FALLBACK_NETWORKS: Record<NetworkType, NetworkInfo> = {
   testnet: {
     rpc: 'https://staging.proxy.fastset.xyz',
-    keyfile: '~/.fast/keys/default.json',
-    network: 'testnet',
-    defaultToken: 'FAST',
+    explorer: 'https://explorer.fast.xyz',
   },
   mainnet: {
     rpc: 'https://api.fast.xyz/proxy',
-    keyfile: '~/.fast/keys/default.json',
-    network: 'mainnet',
-    defaultToken: 'FAST',
+    explorer: 'https://explorer.fast.xyz',
   },
 };
 
-/** Default RPC URL */
-export const DEFAULT_RPC_URL = 'https://staging.proxy.fastset.xyz';
-
-const FAST_KNOWN_TOKENS: Record<string, KnownFastToken> = {
+const FALLBACK_TOKENS: Record<string, KnownFastToken> = {
+  FAST: {
+    symbol: 'FAST',
+    tokenId: 'native',
+    decimals: 9,
+  },
   FASTUSDC: {
     symbol: 'fastUSDC',
     tokenId: '0xb4cf1b9e227bb6a21b959338895dfb39b8d2a96dfa1ce5dd633561c193124cb5',
@@ -37,22 +59,136 @@ const FAST_KNOWN_TOKENS: Record<string, KnownFastToken> = {
   },
 };
 
+/* ─────────────────────────────────────────────────────────────────────────────
+ * Cache (lazy-loaded on first access)
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+let _networksCache: Record<string, NetworkInfo> | null = null;
+let _tokensCache: Record<string, KnownFastToken> | null = null;
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * JSON Loading Helpers
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+async function loadJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function loadNetworks(): Promise<Record<string, NetworkInfo>> {
+  if (_networksCache) return _networksCache;
+
+  // Start with hardcoded fallbacks
+  const merged: Record<string, NetworkInfo> = { ...FALLBACK_NETWORKS };
+
+  // Layer 2: Bundled JSON (imported as module)
+  Object.assign(merged, bundledNetworks as Record<string, NetworkInfo>);
+
+  // Layer 3: User overrides (~/.fast/networks.json)
+  const userPath = path.join(getConfigDir(), 'networks.json');
+  const user = await loadJsonFile<Record<string, NetworkInfo>>(userPath);
+  if (user) {
+    Object.assign(merged, user);
+  }
+
+  _networksCache = merged;
+  return merged;
+}
+
+async function loadTokens(): Promise<Record<string, KnownFastToken>> {
+  if (_tokensCache) return _tokensCache;
+
+  // Start with hardcoded fallbacks
+  const merged: Record<string, KnownFastToken> = { ...FALLBACK_TOKENS };
+
+  // Layer 2: Bundled JSON (imported as module)
+  for (const [key, value] of Object.entries(bundledTokens)) {
+    merged[key.toUpperCase()] = value as KnownFastToken;
+  }
+
+  // Layer 3: User overrides (~/.fast/tokens.json)
+  const userPath = path.join(getConfigDir(), 'tokens.json');
+  const user = await loadJsonFile<Record<string, KnownFastToken>>(userPath);
+  if (user) {
+    for (const [key, value] of Object.entries(user)) {
+      merged[key.toUpperCase()] = value;
+    }
+  }
+
+  _tokensCache = merged;
+  return merged;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * Public API
+ * ───────────────────────────────────────────────────────────────────────────── */
+
 /**
- * Derive the config storage key from network.
- * Testnet uses bare 'fast', mainnet uses 'fast:mainnet'.
+ * Get network info by name (testnet, mainnet, or custom).
+ * Returns null if network is not found.
  */
-export function configKey(network: NetworkType): string {
-  return network === 'mainnet' ? 'fast:mainnet' : 'fast';
+export async function getNetworkInfo(network: string): Promise<NetworkInfo | null> {
+  const networks = await loadNetworks();
+  return networks[network] ?? null;
 }
 
 /**
- * Parse a config key back to network.
+ * Get all known networks.
  */
-export function parseConfigKey(key: string): NetworkType {
-  if (key.endsWith(':mainnet')) return 'mainnet';
-  return 'testnet';
+export async function getAllNetworks(): Promise<Record<string, NetworkInfo>> {
+  return loadNetworks();
 }
 
-export function resolveKnownFastToken(token: string): KnownFastToken | null {
-  return FAST_KNOWN_TOKENS[token.toUpperCase()] ?? null;
+/**
+ * Resolve a known token by symbol (case-insensitive).
+ * Returns null if token is not found.
+ */
+export async function resolveKnownFastToken(token: string): Promise<KnownFastToken | null> {
+  const tokens = await loadTokens();
+  return tokens[token.toUpperCase()] ?? null;
 }
+
+/**
+ * Get all known tokens.
+ */
+export async function getAllTokens(): Promise<Record<string, KnownFastToken>> {
+  return loadTokens();
+}
+
+/**
+ * Get the default RPC URL for a network.
+ */
+export async function getDefaultRpcUrl(network: NetworkType = 'testnet'): Promise<string> {
+  const info = await getNetworkInfo(network);
+  return info?.rpc ?? FALLBACK_NETWORKS.testnet.rpc;
+}
+
+/**
+ * Get the explorer URL for a network.
+ */
+export async function getExplorerUrl(network: NetworkType = 'testnet'): Promise<string> {
+  const info = await getNetworkInfo(network);
+  return info?.explorer ?? FALLBACK_NETWORKS.testnet.explorer;
+}
+
+/**
+ * Clear the cache (useful for testing).
+ */
+export function clearDefaultsCache(): void {
+  _networksCache = null;
+  _tokensCache = null;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * Legacy Exports (for backwards compatibility)
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+/** @deprecated Use getDefaultRpcUrl() instead */
+export const DEFAULT_RPC_URL = FALLBACK_NETWORKS.testnet.rpc;
+
+/** @deprecated Use getNetworkInfo() instead */
+export const FAST_NETWORK_CONFIGS = FALLBACK_NETWORKS;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,19 +17,6 @@ export interface FastOptions {
   keyFile?: string;
 }
 
-/** Network configuration */
-export interface NetworkConfig {
-  rpc: string;
-  keyfile: string;
-  network: string;
-  defaultToken: string;
-}
-
-/** Persisted SDK config (~/.fast/config.json) */
-export interface FastConfig {
-  networks: Record<string, NetworkConfig>;
-}
-
 /** Client returned by the fast() factory — the primary SDK interface for agents */
 export interface FastClient {
   /** Create or load a wallet, persist config. Must be called before other methods. */

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -147,13 +147,7 @@ describe('setup()', () => {
     assert.ok(stat.isFile(), `expected keyfile at ${keyfilePath}`);
   });
 
-  it('creates a config at path.join(tmpDir, "config.json")', async () => {
-    const f = fast();
-    await f.setup();
-    const configPath = path.join(tmpDir, 'config.json');
-    const stat = await fs.stat(configPath);
-    assert.ok(stat.isFile(), `expected config at ${configPath}`);
-  });
+  // Note: config.json is no longer created — network/token config is loaded from JSON files
 });
 
 describe('setup() idempotency', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -4,14 +4,16 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import { getConfigDir, getKeysDir } from '../src/config.js';
 import {
-  getConfigDir,
-  getKeysDir,
-  loadConfig,
-  saveConfig,
-  getNetworkConfig,
-  setNetworkConfig,
-} from '../src/config.js';
+  getNetworkInfo,
+  getAllNetworks,
+  resolveKnownFastToken,
+  getAllTokens,
+  getDefaultRpcUrl,
+  getExplorerUrl,
+  clearDefaultsCache,
+} from '../src/defaults.js';
 
 describe('config', () => {
   let tmpDir: string;
@@ -21,6 +23,7 @@ describe('config', () => {
     originalConfigDir = process.env.FAST_CONFIG_DIR;
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fast-config-test-'));
     process.env.FAST_CONFIG_DIR = tmpDir;
+    clearDefaultsCache();
   });
 
   after(async () => {
@@ -29,6 +32,7 @@ describe('config', () => {
     } else {
       delete process.env.FAST_CONFIG_DIR;
     }
+    clearDefaultsCache();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -43,76 +47,162 @@ describe('config', () => {
       assert.equal(getKeysDir(), path.join(tmpDir, 'keys'));
     });
   });
+});
 
-  describe('loadConfig — no file', () => {
-    it('returns { networks: {} } when no config file exists', async () => {
-      const config = await loadConfig();
-      assert.deepEqual(config, { networks: {} });
+describe('defaults', () => {
+  let tmpDir: string;
+  let originalConfigDir: string | undefined;
+
+  before(async () => {
+    originalConfigDir = process.env.FAST_CONFIG_DIR;
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fast-defaults-test-'));
+    process.env.FAST_CONFIG_DIR = tmpDir;
+    clearDefaultsCache();
+  });
+
+  after(async () => {
+    if (originalConfigDir !== undefined) {
+      process.env.FAST_CONFIG_DIR = originalConfigDir;
+    } else {
+      delete process.env.FAST_CONFIG_DIR;
+    }
+    clearDefaultsCache();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('getNetworkInfo', () => {
+    it('returns testnet config', async () => {
+      const info = await getNetworkInfo('testnet');
+      assert.ok(info);
+      assert.ok(info.rpc.includes('fastset.xyz'));
+      assert.ok(info.explorer);
+    });
+
+    it('returns mainnet config', async () => {
+      const info = await getNetworkInfo('mainnet');
+      assert.ok(info);
+      assert.ok(info.rpc);
+      assert.ok(info.explorer);
+    });
+
+    it('returns null for unknown network', async () => {
+      const info = await getNetworkInfo('unknown-network');
+      assert.equal(info, null);
     });
   });
 
-  describe('saveConfig / loadConfig roundtrip', () => {
-    it('saves and loads config with deep equality', async () => {
-      const config = {
-        networks: {
-          fast: {
-            rpc: 'https://example.com',
-            keyfile: '/tmp/k.json',
-            network: 'testnet',
-            defaultToken: 'FAST',
+  describe('getAllNetworks', () => {
+    it('returns at least testnet and mainnet', async () => {
+      const networks = await getAllNetworks();
+      assert.ok('testnet' in networks);
+      assert.ok('mainnet' in networks);
+    });
+  });
+
+  describe('resolveKnownFastToken', () => {
+    it('resolves FAST token (case-insensitive)', async () => {
+      const fast = await resolveKnownFastToken('FAST');
+      assert.ok(fast);
+      assert.equal(fast.symbol, 'FAST');
+      assert.equal(fast.decimals, 9);
+
+      const fastLower = await resolveKnownFastToken('fast');
+      assert.deepEqual(fastLower, fast);
+    });
+
+    it('resolves fastUSDC token (case-insensitive)', async () => {
+      const usdc = await resolveKnownFastToken('fastUSDC');
+      assert.ok(usdc);
+      assert.equal(usdc.symbol, 'fastUSDC');
+      assert.equal(usdc.decimals, 6);
+      assert.ok(usdc.tokenId.startsWith('0x'));
+
+      const usdcUpper = await resolveKnownFastToken('FASTUSDC');
+      assert.deepEqual(usdcUpper, usdc);
+    });
+
+    it('returns null for unknown token', async () => {
+      const unknown = await resolveKnownFastToken('UNKNOWN_TOKEN');
+      assert.equal(unknown, null);
+    });
+  });
+
+  describe('getAllTokens', () => {
+    it('returns at least FAST and FASTUSDC', async () => {
+      const tokens = await getAllTokens();
+      assert.ok('FAST' in tokens);
+      assert.ok('FASTUSDC' in tokens);
+    });
+  });
+
+  describe('getDefaultRpcUrl', () => {
+    it('returns testnet RPC by default', async () => {
+      const url = await getDefaultRpcUrl();
+      assert.ok(url.includes('fastset.xyz'));
+    });
+
+    it('returns mainnet RPC when specified', async () => {
+      const url = await getDefaultRpcUrl('mainnet');
+      assert.ok(url.includes('fast.xyz'));
+    });
+  });
+
+  describe('getExplorerUrl', () => {
+    it('returns explorer URL', async () => {
+      const url = await getExplorerUrl();
+      assert.ok(url.includes('fast.xyz') || url.includes('explorer'));
+    });
+  });
+
+  describe('user overrides', () => {
+    before(async () => {
+      clearDefaultsCache();
+      // Write user override files
+      await fs.writeFile(
+        path.join(tmpDir, 'networks.json'),
+        JSON.stringify({
+          custom: {
+            rpc: 'https://custom.example.com',
+            explorer: 'https://custom-explorer.example.com',
           },
-        },
-      };
-      await saveConfig(config);
-      const loaded = await loadConfig();
-      assert.deepEqual(loaded, config);
+        })
+      );
+      await fs.writeFile(
+        path.join(tmpDir, 'tokens.json'),
+        JSON.stringify({
+          CUSTOMTOKEN: {
+            symbol: 'CUSTOM',
+            tokenId: '0x1234567890abcdef',
+            decimals: 18,
+          },
+        })
+      );
     });
-  });
 
-  describe('setNetworkConfig / getNetworkConfig', () => {
-    it('getNetworkConfig returns null for a nonexistent network', async () => {
-      const result = await getNetworkConfig('nonexistent');
-      assert.equal(result, null);
+    after(async () => {
+      clearDefaultsCache();
     });
 
-    it('setNetworkConfig persists and getNetworkConfig retrieves the config', async () => {
-      const networkCfg = {
-        rpc: 'https://example.com',
-        keyfile: '/tmp/k.json',
-        network: 'testnet',
-        defaultToken: 'FAST',
-      };
-      await setNetworkConfig('fast', networkCfg);
-      const result = await getNetworkConfig('fast');
-      assert.deepEqual(result, networkCfg);
+    it('loads custom network from user override', async () => {
+      const info = await getNetworkInfo('custom');
+      assert.ok(info);
+      assert.equal(info.rpc, 'https://custom.example.com');
+      assert.equal(info.explorer, 'https://custom-explorer.example.com');
     });
-  });
 
-  describe('config accumulation', () => {
-    it('setting two networks preserves both in the loaded config', async () => {
-      const netCfgA = {
-        rpc: 'https://a.example.com',
-        keyfile: '/tmp/a.json',
-        network: 'testnet',
-        defaultToken: 'FAST',
-      };
-      const netCfgB = {
-        rpc: 'https://b.example.com',
-        keyfile: '/tmp/b.json',
-        network: 'mainnet',
-        defaultToken: 'ETH',
-      };
-      await setNetworkConfig('a', netCfgA);
-      await setNetworkConfig('b', netCfgB);
+    it('loads custom token from user override', async () => {
+      const token = await resolveKnownFastToken('CUSTOMTOKEN');
+      assert.ok(token);
+      assert.equal(token.symbol, 'CUSTOM');
+      assert.equal(token.decimals, 18);
+    });
 
-      const loaded = await loadConfig();
-      assert.ok('a' in loaded.networks);
-      assert.ok('b' in loaded.networks);
+    it('user overrides do not remove bundled defaults', async () => {
+      const testnet = await getNetworkInfo('testnet');
+      assert.ok(testnet);
 
-      const resultA = await getNetworkConfig('a');
-      const resultB = await getNetworkConfig('b');
-      assert.deepEqual(resultA, netCfgA);
-      assert.deepEqual(resultB, netCfgB);
+      const fast = await resolveKnownFastToken('FAST');
+      assert.ok(fast);
     });
   });
 });


### PR DESCRIPTION
## Summary

Refactors the configuration system to use JSON files instead of the write-only `config.json`.

## Changes

### New Files
- `src/data/networks.json` — Bundled network definitions (testnet, mainnet)
- `src/data/tokens.json` — Bundled token definitions (FAST, fastUSDC)

### Configuration Priority
1. **User overrides**: `~/.fast/networks.json`, `~/.fast/tokens.json`
2. **Bundled JSON** (imported as ES modules)
3. **Hardcoded fallbacks** in defaults.ts

### Removed
- `config.json` write logic — It was write-only (never read back by the SDK)
- `NetworkConfig`, `FastConfig` types — No longer needed
- `setNetworkConfig`, `saveConfig`, `loadConfig` — Replaced by JSON loading

### Simplified
- `config.ts` now only provides directory path helpers (`getConfigDir`, `getKeysDir`)
- `defaults.ts` loads bundled JSON via ES module imports (no fs.readFile for bundled data)

## New Structure

```
~/.fast/
├── keys/
│   └── fast.json        # Keypair only
├── networks.json        # Optional: custom networks (user override)
└── tokens.json          # Optional: custom tokens (user override)
```

## Testing

- All 134 tests pass
- Build succeeds
- Pack smoke test passes

## Documentation

Updated `SKILL.md` with new configuration file documentation.