### PR TITLE
fix: add missing Burn claim type to BCS enum

### DIFF
--- a/src/bcs.ts
+++ b/src/bcs.ts
@@ -47,6 +47,11 @@ const MintBcs = bcs.struct('Mint', {
   amount: AmountBcs,
 });
 
+const BurnBcs = bcs.struct('Burn', {
+  token_id: bcs.bytes(32),
+  amount: AmountBcs,
+});
+
 const ExternalClaimBodyBcs = bcs.struct('ExternalClaimBody', {
   verifier_committee: bcs.vector(bcs.bytes(32)),
   verifier_quorum: bcs.u64(),
@@ -63,6 +68,7 @@ const ClaimTypeBcs = bcs.enum('ClaimType', {
   TokenCreation: TokenCreationBcs,
   TokenManagement: TokenManagementBcs,
   Mint: MintBcs,
+  Burn: BurnBcs,
   StateInitialization: bcs.struct('StateInitialization', { dummy: bcs.u8() }),
   StateUpdate: bcs.struct('StateUpdate', { dummy: bcs.u8() }),
   ExternalClaim: ExternalClaimFullBcs,


### PR DESCRIPTION
## Summary

The ClaimType enum was missing the `Burn` variant at index 4, which caused all subsequent variants to have incorrect indices when serialized.

## Problem

- `ExternalClaim` was being serialized as index 6 instead of index 7
- This caused signature verification to fail on the network because the signed message didn't match what the network reconstructed
- `TokenTransfer` (index 0) was unaffected

## Fix

Added `BurnBcs` struct and included it in `ClaimTypeBcs` at the correct position (after Mint, before StateInitialization).

## Testing

Before fix:
```
Error: Signature is not valid: signature error: Verification equation was not satisfied
```

After fix:
```
SUCCESS! TX Hash: 0xed43cf5aafbd273fb051ece4be082ac1b36486cc6c188c4fc29b560e40d5b3ca
```