### PR TITLE
Migrate allset-sdk

### DIFF
--- a/packages/allset-sdk/README.md
+++ b/packages/allset-sdk/README.md
@@ -1,0 +1,231 @@
+# @fastxyz/allset-sdk
+
+AllSet SDK for bridging tokens between [Fast network](https://fast.xyz) and EVM chains.
+
+- **EVM → Fast (deposit):** `executeDeposit()`
+- **Fast → EVM (withdrawal):** `executeIntent()` + intent builder
+- **Pure helpers:** `buildDepositTransaction()`, intent builders, address utils — browser-safe
+
+**Design:** All functions are pure — no embedded chain config, no file system access, no environment variable reads. The caller provides all addresses, URLs, and credentials.
+
+---
+
+## Installation
+
+```bash
+npm install @fastxyz/allset-sdk
+# or
+pnpm add @fastxyz/allset-sdk
+```
+
+**Peer dependencies:** `viem` (used internally)
+
+---
+
+## Quick Start
+
+### Deposit (EVM → Fast)
+
+```ts
+import { createEvmWallet, createEvmExecutor, executeDeposit } from '@fastxyz/allset-sdk';
+
+const account = createEvmWallet('0xYourPrivateKey');
+const evmClients = createEvmExecutor(account, 'https://arb-sepolia.rpc...', 421614);
+
+const result = await executeDeposit({
+  chainId: 421614,
+  bridgeContract: '0xb536...',   // AllSet bridge contract on Arbitrum Sepolia
+  tokenAddress: '0x75fa...',    // USDC on Arbitrum Sepolia
+  amount: '1000000',             // 1 USDC (6 decimals)
+  senderAddress: account.address,
+  receiverAddress: 'fast1abc...', // your Fast address
+  evmClients,
+});
+
+console.log(result.txHash); // EVM transaction hash
+```
+
+### Withdrawal (Fast → EVM)
+
+```ts
+import { executeIntent, buildTransferIntent } from '@fastxyz/allset-sdk';
+
+const intent = buildTransferIntent('0x75fa...', '0xReceiverEVM...');
+
+const result = await executeIntent({
+  fastBridgeAddress: 'fast1bridge...',
+  relayerUrl: 'https://relayer.allset...',
+  crossSignUrl: 'https://cross-sign.allset...',
+  tokenEvmAddress: '0x75fa...',
+  tokenFastTokenId: 'abc123...',  // hex token ID on Fast network (no 0x)
+  amount: '1000000',
+  intents: [intent],
+  fastWallet,                      // @fastxyz/fast-sdk wallet
+});
+```
+
+---
+
+## API Reference
+
+### Wallet & Clients
+
+#### `createEvmWallet(privateKey?): EvmAccount`
+
+Creates an EVM wallet. Generates a new random wallet if `privateKey` is omitted.
+
+```ts
+const account = createEvmWallet();            // random
+const account = createEvmWallet('0xabc123...'); // from existing key
+// account.privateKey — hex key (persist to reuse)
+// account.address    — 0x address
+```
+
+#### `createEvmExecutor(account, rpcUrl, chainId): EvmClients`
+
+Creates viem `walletClient` and `publicClient` for the given chain.
+
+```ts
+const { walletClient, publicClient } = createEvmExecutor(account, rpcUrl, 421614);
+```
+
+Supported chain IDs: `11155111` (Sepolia), `421614` (Arbitrum Sepolia), `42161` (Arbitrum), `8453` (Base).
+
+---
+
+### Bridge Execution
+
+#### `executeDeposit(params): Promise<BridgeResult>`
+
+Executes an EVM → Fast deposit. For ERC-20 tokens, automatically submits an `approve` transaction if the current allowance is insufficient.
+
+```ts
+interface ExecuteDepositParams {
+  chainId: number;
+  bridgeContract: `0x${string}`;
+  tokenAddress: `0x${string}`;
+  isNative?: boolean;        // true for ETH deposits
+  amount: string;            // smallest units as string
+  senderAddress: string;
+  receiverAddress: string;   // Fast bech32m address (fast1...)
+  evmClients: EvmClients;
+}
+```
+
+#### `executeIntent(params): Promise<BridgeResult>`
+
+Executes Fast → EVM bridge with custom intents. Internally:
+1. Transfers tokens to the bridge on Fast network
+2. Cross-signs the transfer certificate
+3. Submits intent claim on Fast network
+4. Cross-signs the intent certificate
+5. Submits to the relayer for EVM execution
+
+```ts
+interface ExecuteIntentParams {
+  fastBridgeAddress: string;
+  relayerUrl: string;
+  crossSignUrl: string;
+  tokenEvmAddress: string;
+  tokenFastTokenId: string;   // hex, no 0x prefix
+  amount: string;
+  intents: Intent[];
+  externalAddress?: string;   // override EVM target (required for depositBack/revoke flows)
+  deadlineSeconds?: number;   // default: 3600
+  fastWallet: FastWalletLike;
+}
+```
+
+#### `evmSign(certificate, crossSignUrl): Promise<EvmSignResult>`
+
+Cross-signs a Fast network certificate with the AllSet cross-sign service.
+
+---
+
+### Intent Builders (Pure)
+
+```ts
+buildTransferIntent(tokenAddress, receiverEvmAddress): Intent
+buildExecuteIntent(targetAddress, calldata, value?): Intent
+buildDepositBackIntent(tokenAddress, fastReceiverAddress): Intent
+buildRevokeIntent(): Intent
+```
+
+---
+
+### Deposit Planning (Pure, Browser-Safe)
+
+#### `buildDepositTransaction(params): DepositTransactionPlan`
+
+Builds a deposit transaction without executing it. Useful for displaying, signing externally, or constructing in a browser.
+
+```ts
+const plan = buildDepositTransaction({
+  chainId: 421614,
+  bridgeContract: '0xb536...',
+  tokenAddress: '0x75fa...',
+  amount: 1000000n,       // bigint
+  receiver: 'fast1abc...',
+});
+// plan.to, plan.data, plan.value — pass to walletClient.sendTransaction()
+```
+
+#### `encodeDepositCalldata(params): Hex`
+
+Encodes only the calldata for a deposit call.
+
+---
+
+### Address Utilities (Pure, Browser-Safe)
+
+```ts
+fastAddressToBytes32(address: string): Hex        // bech32m → 0x bytes32
+fastAddressToBytes(address: string): Uint8Array   // bech32m → Uint8Array
+```
+
+---
+
+### Error Handling
+
+```ts
+import { FastError } from '@fastxyz/allset-sdk';
+
+try {
+  await executeDeposit({ ... });
+} catch (err) {
+  if (err instanceof FastError) {
+    console.error(err.code);     // 'TX_FAILED' | 'INVALID_ADDRESS' | 'INVALID_PARAMS'
+    console.error(err.message);
+    console.error(err.context);
+  }
+}
+```
+
+---
+
+## Types
+
+```ts
+interface BridgeResult {
+  txHash: string;
+  orderId: string;
+  estimatedTime?: string;
+}
+
+interface FastWalletLike {
+  readonly address: string;  // fast1... bech32m
+  submit(params: { claim: Record<string, unknown> }): Promise<{
+    txHash: string;
+    certificate: unknown;
+  }>;
+}
+```
+
+---
+
+## Changelog
+
+**v0.x (current)**
+- Pure-function API — no `AllSetProvider`, no embedded config, no keyfile loading
+- Single entrypoint `@fastxyz/allset-sdk` (no sub-path exports)
+- All config values passed as explicit function parameters

--- a/packages/allset-sdk/README.md
+++ b/packages/allset-sdk/README.md
@@ -3,7 +3,7 @@
 AllSet SDK for bridging tokens between [Fast network](https://fast.xyz) and EVM chains.
 
 - **EVM → Fast (deposit):** `executeDeposit()`
-- **Fast → EVM (withdrawal):** `executeIntent()` + intent builder
+- **Fast → EVM (withdrawal):** `executeWithdraw()` or `executeIntent()` + intent builders
 - **Pure helpers:** `buildDepositTransaction()`, intent builders, address utils — browser-safe
 
 **Design:** All functions are pure — no embedded chain config, no file system access, no environment variable reads. The caller provides all addresses, URLs, and credentials.
@@ -30,7 +30,7 @@ pnpm add @fastxyz/allset-sdk
 import { createEvmWallet, createEvmExecutor, executeDeposit } from '@fastxyz/allset-sdk';
 
 const account = createEvmWallet('0xYourPrivateKey');
-const evmClients = createEvmExecutor(account, 'https://arb-sepolia.rpc...', 421614);
+const evmClients = createEvmExecutor(account, 'https://your-evm-rpc...', 421614);
 
 const result = await executeDeposit({
   chainId: 421614,
@@ -48,19 +48,48 @@ console.log(result.txHash); // EVM transaction hash
 ### Withdrawal (Fast → EVM)
 
 ```ts
-import { executeIntent, buildTransferIntent } from '@fastxyz/allset-sdk';
+import { Signer, FastProvider } from '@fastxyz/fast-sdk';
+import { executeWithdraw } from '@fastxyz/allset-sdk';
 
-const intent = buildTransferIntent('0x75fa...', '0xReceiverEVM...');
+const signer = new Signer('0xYourPrivateKey');
+const provider = new FastProvider({ rpcUrl: 'https://your-fast-rpc...' });
 
-const result = await executeIntent({
+const result = await executeWithdraw({
   fastBridgeAddress: 'fast1bridge...',
   relayerUrl: 'https://relayer.allset...',
   crossSignUrl: 'https://cross-sign.allset...',
   tokenEvmAddress: '0x75fa...',
   tokenFastTokenId: 'abc123...',  // hex token ID on Fast network (no 0x)
   amount: '1000000',
-  intents: [intent],
-  fastWallet,                      // @fastxyz/fast-sdk wallet
+  receiverEvmAddress: '0xReceiverEVM...',
+  networkId: 'fast:testnet',      // or 'fast:mainnet'
+  signer,
+  provider,
+});
+
+console.log(result.txHash);
+```
+
+### Withdrawal with custom intents
+
+```ts
+import { Signer, FastProvider } from '@fastxyz/fast-sdk';
+import { executeIntent, buildTransferIntent } from '@fastxyz/allset-sdk';
+
+const signer = new Signer('0xYourPrivateKey');
+const provider = new FastProvider({ rpcUrl: 'https://...' });
+
+const result = await executeIntent({
+  fastBridgeAddress: 'fast1bridge...',
+  relayerUrl: 'https://relayer.allset...',
+  crossSignUrl: 'https://cross-sign.allset...',
+  tokenEvmAddress: '0x75fa...',
+  tokenFastTokenId: 'abc123...',
+  amount: '1000000',
+  intents: [buildTransferIntent('0x75fa...', '0xReceiverEVM...')],
+  networkId: 'fast:testnet',
+  signer,
+  provider,
 });
 ```
 
@@ -89,7 +118,7 @@ Creates viem `walletClient` and `publicClient` for the given chain.
 const { walletClient, publicClient } = createEvmExecutor(account, rpcUrl, 421614);
 ```
 
-Supported chain IDs: `11155111` (Sepolia), `421614` (Arbitrum Sepolia), `42161` (Arbitrum), `8453` (Base).
+Supported chain IDs: `1` (Ethereum), `11155111` (Sepolia), `421614` (Arbitrum Sepolia), `42161` (Arbitrum), `8453` (Base).
 
 ---
 
@@ -109,6 +138,26 @@ interface ExecuteDepositParams {
   senderAddress: string;
   receiverAddress: string;   // Fast bech32m address (fast1...)
   evmClients: EvmClients;
+}
+```
+
+#### `executeWithdraw(params): Promise<BridgeResult>`
+
+Executes a simple Fast → EVM token withdrawal. Automatically builds a `DynamicTransfer` intent for the given receiver address.
+
+```ts
+interface ExecuteWithdrawParams {
+  fastBridgeAddress: string;
+  relayerUrl: string;
+  crossSignUrl: string;
+  tokenEvmAddress: string;
+  tokenFastTokenId: string;   // hex, no 0x prefix
+  amount: string;
+  receiverEvmAddress: string; // EVM address to receive tokens
+  deadlineSeconds?: number;   // default: 3600
+  networkId: string;          // 'fast:testnet' | 'fast:mainnet' | ...
+  signer: Signer;             // from @fastxyz/fast-sdk
+  provider: FastProvider;     // from @fastxyz/fast-sdk
 }
 ```
 
@@ -132,7 +181,9 @@ interface ExecuteIntentParams {
   intents: Intent[];
   externalAddress?: string;   // override EVM target (required for depositBack/revoke flows)
   deadlineSeconds?: number;   // default: 3600
-  fastWallet: FastWalletLike;
+  networkId: string;          // 'fast:testnet' | 'fast:mainnet' | ...
+  signer: Signer;             // from @fastxyz/fast-sdk
+  provider: FastProvider;     // from @fastxyz/fast-sdk
 }
 ```
 
@@ -191,7 +242,7 @@ fastAddressToBytes(address: string): Uint8Array   // bech32m → Uint8Array
 import { FastError } from '@fastxyz/allset-sdk';
 
 try {
-  await executeDeposit({ ... });
+  await executeWithdraw({ ... });
 } catch (err) {
   if (err instanceof FastError) {
     console.error(err.code);     // 'TX_FAILED' | 'INVALID_ADDRESS' | 'INVALID_PARAMS'
@@ -211,14 +262,6 @@ interface BridgeResult {
   orderId: string;
   estimatedTime?: string;
 }
-
-interface FastWalletLike {
-  readonly address: string;  // fast1... bech32m
-  submit(params: { claim: Record<string, unknown> }): Promise<{
-    txHash: string;
-    certificate: unknown;
-  }>;
-}
 ```
 
 ---
@@ -226,6 +269,9 @@ interface FastWalletLike {
 ## Changelog
 
 **v0.x (current)**
+- `executeWithdraw()` — new convenience function for simple Fast → EVM withdrawals
+- `executeIntent()` / `executeWithdraw()` now accept `signer`, `provider`, `networkId` from `@fastxyz/fast-sdk` (replaces `FastWalletLike`)
+- Added Ethereum mainnet (chainId 1) support
 - Pure-function API — no `AllSetProvider`, no embedded config, no keyfile loading
 - Single entrypoint `@fastxyz/allset-sdk` (no sub-path exports)
 - All config values passed as explicit function parameters

--- a/packages/allset-sdk/SKILL.md
+++ b/packages/allset-sdk/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: allset-sdk
+description: >
+  AllSet SDK for bridging tokens between Fast network and EVM chains. Use executeDeposit
+  for EVM → Fast deposits and executeIntent for Fast → EVM withdrawals or custom operations.
+  All functions are pure — no embedded config, no file system access. Caller provides all
+  chain/contract addresses.
+metadata:
+  short-description: Bridge tokens between Fast and EVM chains (pure functions, no config).
+  compatibility: Node.js 20+; browser-safe pure helpers (address, deposit, intents).
+---
+
+# AllSet SDK Skill
+
+## When to Use This Skill
+
+**USE this skill when the user wants to:**
+- Bridge tokens from EVM to Fast network (deposit / EVM → Fast)
+- Bridge tokens from Fast to EVM (withdrawal / Fast → EVM)
+- Execute custom intents on EVM via AllSet bridge
+- Build or plan deposit transactions (pure, browser-safe helpers)
+- Set up EVM wallets for bridging
+
+**DO NOT use this skill for:**
+- Fast-only operations (balance, send, sign) → use `@fastxyz/fast-sdk`
+- EVM-only operations without bridging
+- Swaps, lending, staking, or yield strategies
+
+---
+
+## Single Entrypoint
+
+```ts
+import { ... } from '@fastxyz/allset-sdk';
+```
+
+All functions are exported from the single root entry. No sub-paths.
+
+---
+
+## Workflows
+
+### 1. Setup EVM Wallet
+
+```ts
+import { createEvmWallet, createEvmExecutor } from '@fastxyz/allset-sdk';
+
+// Generate a new wallet (save privateKey to reuse)
+const account = createEvmWallet();
+console.log(account.address);    // 0x...
+console.log(account.privateKey); // persist this
+
+// Or restore from existing private key
+const account = createEvmWallet('0x1234...64hexchars');
+
+// Create viem clients (needed by executeDeposit)
+const evmClients = createEvmExecutor(account, rpcUrl, chainId);
+```
+
+`createEvmWallet` accepts an optional hex private key. No keyfile loading.
+
+---
+
+### 2. Deposit (EVM → Fast)
+
+**When:** User wants to move tokens from an EVM chain to their Fast address.
+
+**Prerequisites:** EVM wallet with sufficient token balance + gas.
+
+```ts
+import { executeDeposit } from '@fastxyz/allset-sdk';
+
+const result = await executeDeposit({
+  chainId: 421614,                          // Arbitrum Sepolia
+  bridgeContract: '0xb536...',             // AllSet bridge contract on EVM
+  tokenAddress: '0x75fa...',              // ERC-20 token contract
+  isNative: false,                          // true for ETH deposits
+  amount: '1000000',                        // smallest units (e.g. 1 USDC = 1_000_000)
+  senderAddress: account.address,
+  receiverAddress: 'fast1abc...',          // Fast network bech32m address
+  evmClients,
+});
+
+console.log(result.txHash);               // EVM tx hash
+```
+
+For ERC-20 tokens, `executeDeposit` automatically handles `approve` if allowance is insufficient.
+
+**All addresses and URLs must be provided by the caller** — the SDK contains no embedded chain config.
+
+---
+
+### 3. Withdrawal (Fast → EVM)
+
+**When:** User wants to move tokens from Fast network to an EVM address.
+
+**Prerequisites:** Fast wallet with sufficient token balance.
+
+```ts
+import { executeIntent, buildTransferIntent } from '@fastxyz/allset-sdk';
+
+// Simple withdrawal: transfer tokens to an EVM address
+const intent = buildTransferIntent(tokenEvmAddress, receiverEvmAddress);
+
+const result = await executeIntent({
+  fastBridgeAddress: 'fast1bridge...',    // AllSet bridge address on Fast network
+  relayerUrl: 'https://relayer.allset...', // AllSet relayer URL for destination chain
+  crossSignUrl: 'https://cross-sign...',  // AllSet cross-sign service URL
+  tokenEvmAddress: '0x75fa...',           // Token contract on EVM
+  tokenFastTokenId: 'abc123...',          // Token ID on Fast network (hex, no 0x)
+  amount: '1000000',
+  intents: [intent],
+  fastWallet,                              // Fast wallet (FastWalletLike)
+});
+
+console.log(result.txHash);
+```
+
+---
+
+### 4. Execute Custom Intent
+
+**When:** User wants to call a contract on EVM after bridging from Fast.
+
+```ts
+import { executeIntent, buildExecuteIntent } from '@fastxyz/allset-sdk';
+
+const intent = buildExecuteIntent(targetContractAddress, encodedCalldata);
+
+const result = await executeIntent({
+  fastBridgeAddress: 'fast1bridge...',
+  relayerUrl: 'https://relayer.allset...',
+  crossSignUrl: 'https://cross-sign...',
+  tokenEvmAddress: '0x75fa...',
+  tokenFastTokenId: 'abc123...',
+  amount: '1000000',
+  intents: [intent],
+  fastWallet,
+});
+```
+
+---
+
+### 5. Plan Deposit (Pure, No Execution)
+
+**When:** Building a transaction to display or sign externally (browser-safe).
+
+```ts
+import { buildDepositTransaction } from '@fastxyz/allset-sdk';
+
+const plan = buildDepositTransaction({
+  chainId: 421614,
+  bridgeContract: '0xb536...',
+  tokenAddress: '0x75fa...',
+  amount: 1000000n,       // bigint
+  receiver: 'fast1abc...',
+});
+
+// plan.to, plan.data, plan.value — ready to send via walletClient
+```
+
+---
+
+### 6. Address Utilities
+
+```ts
+import { fastAddressToBytes32, fastAddressToBytes } from '@fastxyz/allset-sdk';
+
+const bytes32 = fastAddressToBytes32('fast1abc...');  // Hex<0x...>
+const bytes   = fastAddressToBytes('fast1abc...');    // Uint8Array
+```
+
+---
+
+### 7. Intent Builders (Pure)
+
+```ts
+import {
+  buildTransferIntent,
+  buildExecuteIntent,
+  buildDepositBackIntent,
+  buildRevokeIntent,
+} from '@fastxyz/allset-sdk';
+
+// Transfer tokens to an EVM address
+const i1 = buildTransferIntent(tokenAddress, receiverEvmAddress);
+
+// Call a contract on EVM
+const i2 = buildExecuteIntent(targetAddress, calldata, valueInWei?);
+
+// Deposit tokens back to a Fast address
+const i3 = buildDepositBackIntent(tokenAddress, fastReceiverAddress);
+
+// Revoke a pending intent
+const i4 = buildRevokeIntent();
+```
+
+---
+
+### 8. evmSign (Cross-signing)
+
+```ts
+import { evmSign } from '@fastxyz/allset-sdk';
+
+// Used internally by executeIntent. Available standalone for advanced flows.
+const result = await evmSign(certificate, crossSignUrl);
+// result: { transaction: number[], signature: string }
+```
+
+---
+
+## Error Handling
+
+```ts
+import { FastError } from '@fastxyz/allset-sdk';
+
+try {
+  await executeDeposit({ ... });
+} catch (err) {
+  if (err instanceof FastError) {
+    console.error(err.code);     // e.g. 'TX_FAILED', 'INVALID_ADDRESS', 'INVALID_PARAMS'
+    console.error(err.message);
+    console.error(err.context);  // { note: '...' }
+  }
+}
+```
+
+**Error codes:**
+| Code | When |
+|---|---|
+| `TX_FAILED` | EVM tx reverted, cross-sign failed, relayer rejected |
+| `INVALID_ADDRESS` | Bad Fast address passed as receiver |
+| `INVALID_PARAMS` | Missing/wrong params (e.g. no intents) |
+
+---
+
+## Supported Chains (CHAIN_MAP)
+
+| Chain ID | Network |
+|---|---|
+| 11155111 | Sepolia |
+| 421614 | Arbitrum Sepolia |
+| 42161 | Arbitrum One |
+| 8453 | Base |
+
+`createEvmExecutor` throws if the chain ID is not in this map.
+
+---
+
+## FastWalletLike Interface
+
+`executeIntent` requires a `fastWallet` that implements:
+
+```ts
+interface FastWalletLike {
+  readonly address: string;  // fast1... bech32m
+  submit(params: {
+    claim: Record<string, unknown>;
+  }): Promise<{
+    txHash: string;
+    certificate: unknown;
+  }>;
+}
+```
+
+Use `@fastxyz/fast-sdk` to create a conforming Fast wallet.

--- a/packages/allset-sdk/package.json
+++ b/packages/allset-sdk/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@fastxyz/allset-sdk",
+  "version": "0.1.9",
+  "description": "AllSet SDK for AllSet bridge flows between Fast and EVM testnets",
+  "keywords": ["allset", "sdk", "bridge", "fast", "blockchain"],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --out-dir dist",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "dev": "tsup src/index.ts --format esm --dts --watch --out-dir dist"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "author": "Fast.xyz",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@fastxyz/fast-sdk": "workspace:*",
+    "@mysten/bcs": "^2.0.3",
+    "@noble/ed25519": "^3.0.1",
+    "@noble/hashes": "^2.0.1",
+    "bech32": "^2.0.0",
+    "viem": "^2.46.2"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0"
+  }
+}

--- a/packages/allset-sdk/src/address.ts
+++ b/packages/allset-sdk/src/address.ts
@@ -1,0 +1,36 @@
+import { bech32m } from 'bech32';
+import type { Hex } from 'viem';
+
+export function bytesToHex(bytes: Uint8Array): Hex {
+  let hex = '';
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, '0');
+  }
+  return `0x${hex}` as Hex;
+}
+
+export function fastAddressToBytes(address: string): Uint8Array {
+  let decoded: ReturnType<typeof bech32m.decode>;
+
+  try {
+    decoded = bech32m.decode(address, 90);
+  } catch (error) {
+    throw new Error(`Invalid Fast address "${address}": ${(error as Error).message}`);
+  }
+
+  const { prefix, words } = decoded;
+  if (prefix !== 'fast') {
+    throw new Error(`Fast address must use the "fast" prefix. Got: "${prefix}"`);
+  }
+
+  const bytes = new Uint8Array(bech32m.fromWords(words));
+  if (bytes.length !== 32) {
+    throw new Error(`Fast address must decode to 32 bytes. Got: ${bytes.length}`);
+  }
+
+  return bytes;
+}
+
+export function fastAddressToBytes32(address: string): Hex {
+  return bytesToHex(fastAddressToBytes(address));
+}

--- a/packages/allset-sdk/src/address.ts
+++ b/packages/allset-sdk/src/address.ts
@@ -1,36 +1,14 @@
-import { bech32m } from 'bech32';
+import { fromFastAddress, toHex } from '@fastxyz/fast-sdk';
 import type { Hex } from 'viem';
 
-export function bytesToHex(bytes: Uint8Array): Hex {
-  let hex = '';
-  for (const byte of bytes) {
-    hex += byte.toString(16).padStart(2, '0');
-  }
-  return `0x${hex}` as Hex;
-}
-
 export function fastAddressToBytes(address: string): Uint8Array {
-  let decoded: ReturnType<typeof bech32m.decode>;
-
   try {
-    decoded = bech32m.decode(address, 90);
-  } catch (error) {
-    throw new Error(`Invalid Fast address "${address}": ${(error as Error).message}`);
+    return fromFastAddress(address);
+  } catch (err) {
+    throw new Error(`Invalid Fast address "${address}": ${(err as Error).message}`);
   }
-
-  const { prefix, words } = decoded;
-  if (prefix !== 'fast') {
-    throw new Error(`Fast address must use the "fast" prefix. Got: "${prefix}"`);
-  }
-
-  const bytes = new Uint8Array(bech32m.fromWords(words));
-  if (bytes.length !== 32) {
-    throw new Error(`Fast address must decode to 32 bytes. Got: ${bytes.length}`);
-  }
-
-  return bytes;
 }
 
 export function fastAddressToBytes32(address: string): Hex {
-  return bytesToHex(fastAddressToBytes(address));
+  return toHex(fastAddressToBytes(address)) as Hex;
 }

--- a/packages/allset-sdk/src/bridge.ts
+++ b/packages/allset-sdk/src/bridge.ts
@@ -1,0 +1,411 @@
+import { decodeAbiParameters, encodeAbiParameters } from 'viem';
+import { FastError } from './errors.js';
+import { fastAddressToBytes } from './address.js';
+import { buildDepositTransaction } from './deposit.js';
+import { IntentAction, type Intent } from './intents.js';
+import { ERC20_ABI, type EvmClients } from './evm-executor.js';
+import type { BridgeResult, ExecuteDepositParams, ExecuteIntentParams } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function hexToUint8Array(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function amountToHex(amount: string): string {
+  return BigInt(amount).toString(16);
+}
+
+function bigIntToNumber(obj: unknown): unknown {
+  if (typeof obj === 'bigint') return Number(obj);
+  if (Array.isArray(obj)) return obj.map(bigIntToNumber);
+  if (obj !== null && typeof obj === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      result[key] = bigIntToNumber(value);
+    }
+    return result;
+  }
+  return obj;
+}
+
+function resolveExternalAddress(
+  intents: Intent[],
+  externalAddressOverride?: string,
+): `0x${string}` | null {
+  if (externalAddressOverride) return externalAddressOverride as `0x${string}`;
+
+  for (const intent of intents) {
+    if (intent.action === IntentAction.DynamicTransfer) {
+      try {
+        const [, receiver] = decodeAbiParameters(
+          [{ type: 'address' }, { type: 'address' }],
+          intent.payload,
+        );
+        return receiver;
+      } catch { continue; }
+    }
+    if (intent.action === IntentAction.Execute) {
+      try {
+        const [target] = decodeAbiParameters(
+          [{ type: 'address' }, { type: 'bytes' }],
+          intent.payload,
+        );
+        return target;
+      } catch { continue; }
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// EVM transaction helpers
+// ---------------------------------------------------------------------------
+
+async function sendTx(
+  clients: EvmClients,
+  tx: { to: string; data: string; value: string; gas?: string },
+): Promise<{ txHash: string; status: 'success' | 'reverted' }> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const walletClient = clients.walletClient as any;
+  const hash = await walletClient.sendTransaction({
+    to: tx.to as `0x${string}`,
+    data: tx.data as `0x${string}`,
+    value: BigInt(tx.value),
+    gas: tx.gas ? BigInt(tx.gas) : undefined,
+  });
+  const receipt = await clients.publicClient.waitForTransactionReceipt({ hash });
+  return { txHash: hash, status: receipt.status === 'success' ? 'success' : 'reverted' };
+}
+
+async function checkAllowance(
+  clients: EvmClients,
+  token: string,
+  spender: string,
+  owner: string,
+): Promise<bigint> {
+  return clients.publicClient.readContract({
+    address: token as `0x${string}`,
+    abi: ERC20_ABI,
+    functionName: 'allowance',
+    args: [owner as `0x${string}`, spender as `0x${string}`],
+  });
+}
+
+async function approveErc20(
+  clients: EvmClients,
+  token: string,
+  spender: string,
+  amount: string,
+): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const walletClient = clients.walletClient as any;
+  const hash = await walletClient.writeContract({
+    address: token as `0x${string}`,
+    abi: ERC20_ABI,
+    functionName: 'approve',
+    args: [spender as `0x${string}`, BigInt(amount)],
+  });
+  await clients.publicClient.waitForTransactionReceipt({ hash });
+}
+
+// ---------------------------------------------------------------------------
+// evmSign
+// ---------------------------------------------------------------------------
+
+export interface EvmSignResult {
+  transaction: number[];
+  signature: string;
+}
+
+/**
+ * Request EVM cross-signing for a Fast network certificate.
+ *
+ * @param certificate - Certificate from fastWallet.submit()
+ * @param crossSignUrl - AllSet cross-sign service URL (required)
+ */
+export async function evmSign(
+  certificate: unknown,
+  crossSignUrl: string,
+): Promise<EvmSignResult> {
+  const serialized = bigIntToNumber(certificate);
+  const res = await fetch(crossSignUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'crossSign_evmSignCertificate',
+      params: { certificate: serialized },
+    }),
+  });
+
+  if (!res.ok) {
+    throw new FastError('TX_FAILED', `Cross-sign request failed: ${res.status}`, {
+      note: 'The AllSet cross-sign service rejected the request.',
+    });
+  }
+
+  const json = await res.json() as {
+    result?: { transaction: number[]; signature: string };
+    error?: { message: string };
+  };
+
+  if (json.error) {
+    throw new FastError('TX_FAILED', `Cross-sign error: ${json.error.message}`, {
+      note: 'The certificate could not be cross-signed.',
+    });
+  }
+
+  if (!json.result?.transaction || !json.result?.signature) {
+    throw new FastError('TX_FAILED', 'Cross-sign returned invalid response', {
+      note: 'Missing transaction or signature in response.',
+    });
+  }
+
+  return json.result;
+}
+
+// ---------------------------------------------------------------------------
+// executeDeposit (EVM → Fast)
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a deposit from an EVM chain to the Fast network.
+ *
+ * All configuration values must be provided by the caller.
+ *
+ * @example
+ * ```ts
+ * const result = await executeDeposit({
+ *   chainId: 421614,
+ *   bridgeContract: '0xb536...',
+ *   tokenAddress: '0x75fa...',
+ *   amount: '1000000',
+ *   senderAddress: '0xYourEvmAddress',
+ *   receiverAddress: 'fast1abc...',
+ *   evmClients,
+ * });
+ * ```
+ */
+export async function executeDeposit(params: ExecuteDepositParams): Promise<BridgeResult> {
+  const { chainId, bridgeContract, tokenAddress, isNative = false, amount, senderAddress, receiverAddress, evmClients } = params;
+
+  let depositPlan;
+  try {
+    depositPlan = buildDepositTransaction({
+      chainId,
+      bridgeContract,
+      tokenAddress,
+      isNative,
+      amount: BigInt(amount),
+      receiver: receiverAddress,
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new FastError('INVALID_ADDRESS', `Failed to decode Fast receiver address "${receiverAddress}": ${msg}`, {
+      note: 'The receiver address must be a valid Fast network bech32m address (fast1...).',
+    });
+  }
+
+  let txHash: string;
+
+  if (isNative) {
+    const receipt = await sendTx(evmClients, {
+      to: depositPlan.to,
+      data: depositPlan.data,
+      value: depositPlan.value.toString(),
+    });
+    if (receipt.status === 'reverted') {
+      throw new FastError('TX_FAILED', `Deposit transaction reverted: ${receipt.txHash}`, {
+        note: 'Check that you have sufficient ETH balance.',
+      });
+    }
+    txHash = receipt.txHash;
+  } else {
+    const requiredAmount = BigInt(amount);
+    const currentAllowance = await checkAllowance(evmClients, tokenAddress, bridgeContract, senderAddress);
+    if (currentAllowance < requiredAmount) {
+      await approveErc20(evmClients, tokenAddress, bridgeContract, amount);
+    }
+    const receipt = await sendTx(evmClients, {
+      to: depositPlan.to,
+      data: depositPlan.data,
+      value: depositPlan.value.toString(),
+    });
+    if (receipt.status === 'reverted') {
+      throw new FastError('TX_FAILED', `Deposit transaction reverted: ${receipt.txHash}`, {
+        note: 'Check that you have sufficient token balance and the approval succeeded.',
+      });
+    }
+    txHash = receipt.txHash;
+  }
+
+  return { txHash, orderId: txHash, estimatedTime: '1-5 minutes' };
+}
+
+// ---------------------------------------------------------------------------
+// executeIntent (Fast → EVM)
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute intents on an EVM chain after transferring tokens from the Fast network.
+ *
+ * This is the core function for all Fast→EVM flows:
+ * - Simple withdrawal: use buildTransferIntent + executeIntent
+ * - Custom contract call: use buildExecuteIntent + executeIntent
+ * - Deposit back to Fast: use buildDepositBackIntent + executeIntent
+ *
+ * All configuration values must be provided by the caller.
+ *
+ * @example
+ * ```ts
+ * // Simple withdrawal (Fast → EVM transfer)
+ * const intent = buildTransferIntent(tokenEvmAddress, receiverEvmAddress);
+ * const result = await executeIntent({
+ *   fastBridgeAddress: 'fast1...',
+ *   relayerUrl: 'https://...',
+ *   crossSignUrl: 'https://...',
+ *   tokenEvmAddress: '0x...',
+ *   tokenFastTokenId: 'abc123...',
+ *   amount: '1000000',
+ *   intents: [intent],
+ *   fastWallet,
+ * });
+ * ```
+ */
+export async function executeIntent(params: ExecuteIntentParams): Promise<BridgeResult> {
+  const {
+    fastBridgeAddress,
+    relayerUrl,
+    crossSignUrl,
+    tokenEvmAddress,
+    tokenFastTokenId,
+    amount,
+    intents,
+    externalAddress: externalAddressOverride,
+    deadlineSeconds = 3600,
+    fastWallet,
+  } = params;
+
+  if (!intents || intents.length === 0) {
+    throw new FastError('INVALID_PARAMS', 'executeIntent requires at least one intent', {
+      note: 'Use intent builders like buildTransferIntent(), buildExecuteIntent(), etc.',
+    });
+  }
+
+  if (externalAddressOverride && !externalAddressOverride.startsWith('0x')) {
+    throw new FastError('INVALID_PARAMS', 'executeIntent externalAddress must be an EVM address', {
+      note: 'Pass a 0x-prefixed address for the relayer target.',
+    });
+  }
+
+  const tokenId = hexToUint8Array(tokenFastTokenId);
+
+  // Step 1: Transfer tokens to bridge address on Fast network
+  const transferResult = await fastWallet.submit({
+    claim: {
+      TokenTransfer: {
+        token_id: tokenId,
+        recipient: fastAddressToBytes(fastBridgeAddress),
+        amount: amountToHex(amount),
+        user_data: null,
+      },
+    },
+  });
+
+  // Step 2: Cross-sign the transfer certificate
+  const transferCrossSign = await evmSign(transferResult.certificate, crossSignUrl);
+  const transferFastTxId = transferResult.txHash as `0x${string}`;
+
+  // Step 3: Build and encode the intent claim
+  const deadline = BigInt(Math.floor(Date.now() / 1000) + deadlineSeconds);
+  const intentClaimEncoded = encodeAbiParameters(
+    [{
+      type: 'tuple',
+      components: [
+        { name: 'transferFastTxId', type: 'bytes32' },
+        { name: 'deadline', type: 'uint256' },
+        {
+          name: 'intents',
+          type: 'tuple[]',
+          components: [
+            { name: 'action', type: 'uint8' },
+            { name: 'payload', type: 'bytes' },
+            { name: 'value', type: 'uint256' },
+          ],
+        },
+      ],
+    }],
+    [{ transferFastTxId, deadline, intents: intents.map(i => ({ action: i.action, payload: i.payload, value: i.value })) }],
+  );
+
+  const intentBytes = hexToUint8Array(intentClaimEncoded);
+
+  // Step 4: Submit intent claim on Fast network
+  const intentResult = await fastWallet.submit({
+    claim: {
+      ExternalClaim: {
+        claim: {
+          verifier_committee: [] as Uint8Array[],
+          verifier_quorum: 0,
+          claim_data: Array.from(intentBytes),
+        },
+        signatures: [] as Array<[Uint8Array, Uint8Array]>,
+      },
+    },
+  });
+
+  // Step 5: Cross-sign the intent certificate
+  const intentCrossSign = await evmSign(intentResult.certificate, crossSignUrl);
+
+  // Step 6: Resolve external address and submit to relayer
+  const externalAddress = resolveExternalAddress(intents, externalAddressOverride);
+  if (!externalAddress) {
+    throw new FastError(
+      'INVALID_PARAMS',
+      'executeIntent requires externalAddress when intents do not include a transfer recipient or execute target',
+      { note: 'Pass externalAddress for flows like buildDepositBackIntent() or buildRevokeIntent().' },
+    );
+  }
+
+  const relayerBody = {
+    encoded_transfer_claim: Array.from(new Uint8Array(transferCrossSign.transaction.map(Number))),
+    transfer_proof: transferCrossSign.signature,
+    transfer_fast_tx_id: transferResult.txHash,
+    transfer_claim_id: transferResult.txHash,
+    fastset_address: fastWallet.address,
+    external_address: externalAddress,
+    encoded_intent_claim: Array.from(new Uint8Array(intentCrossSign.transaction.map(Number))),
+    intent_proof: intentCrossSign.signature,
+    intent_fast_tx_id: intentResult.txHash,
+    intent_claim_id: intentResult.txHash,
+    external_token_address: tokenEvmAddress,
+  };
+
+  const relayRes = await fetch(`${relayerUrl}/relay`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(relayerBody),
+  });
+
+  if (!relayRes.ok) {
+    const text = await relayRes.text();
+    throw new FastError('TX_FAILED', `Relayer request failed (${relayRes.status}): ${text}`, {
+      note: 'The intent was submitted to Fast network but the relayer rejected it. Try again.',
+    });
+  }
+
+  return {
+    txHash: transferResult.txHash,
+    orderId: transferFastTxId,
+    estimatedTime: '1-5 minutes',
+  };
+}

--- a/packages/allset-sdk/src/bridge.ts
+++ b/packages/allset-sdk/src/bridge.ts
@@ -1,10 +1,11 @@
 import { decodeAbiParameters, encodeAbiParameters } from 'viem';
+import { FastProvider, Signer, TransactionBuilder, toHex } from '@fastxyz/fast-sdk';
 import { FastError } from './errors.js';
 import { fastAddressToBytes } from './address.js';
 import { buildDepositTransaction } from './deposit.js';
-import { IntentAction, type Intent } from './intents.js';
+import { IntentAction, buildTransferIntent, type Intent } from './intents.js';
 import { ERC20_ABI, type EvmClients } from './evm-executor.js';
-import type { BridgeResult, ExecuteDepositParams, ExecuteIntentParams } from './types.js';
+import type { BridgeResult, ExecuteDepositParams, ExecuteIntentParams, ExecuteWithdrawParams } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -17,10 +18,6 @@ function hexToUint8Array(hex: string): Uint8Array {
     bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
   }
   return bytes;
-}
-
-function amountToHex(amount: string): string {
-  return BigInt(amount).toString(16);
 }
 
 function bigIntToNumber(obj: unknown): unknown {
@@ -259,7 +256,7 @@ export async function executeDeposit(params: ExecuteDepositParams): Promise<Brid
  * Execute intents on an EVM chain after transferring tokens from the Fast network.
  *
  * This is the core function for all Fast→EVM flows:
- * - Simple withdrawal: use buildTransferIntent + executeIntent
+ * - Simple withdrawal: use buildTransferIntent + executeIntent (or use executeWithdraw)
  * - Custom contract call: use buildExecuteIntent + executeIntent
  * - Deposit back to Fast: use buildDepositBackIntent + executeIntent
  *
@@ -267,7 +264,11 @@ export async function executeDeposit(params: ExecuteDepositParams): Promise<Brid
  *
  * @example
  * ```ts
- * // Simple withdrawal (Fast → EVM transfer)
+ * import { Signer, FastProvider } from '@fastxyz/fast-sdk';
+ *
+ * const signer = new Signer(privateKeyHex);
+ * const provider = new FastProvider({ rpcUrl: 'https://proxy.fast.xyz' });
+ *
  * const intent = buildTransferIntent(tokenEvmAddress, receiverEvmAddress);
  * const result = await executeIntent({
  *   fastBridgeAddress: 'fast1...',
@@ -277,7 +278,9 @@ export async function executeDeposit(params: ExecuteDepositParams): Promise<Brid
  *   tokenFastTokenId: 'abc123...',
  *   amount: '1000000',
  *   intents: [intent],
- *   fastWallet,
+ *   signer,
+ *   provider,
+ *   networkId: 'fast:testnet',
  * });
  * ```
  */
@@ -292,7 +295,9 @@ export async function executeIntent(params: ExecuteIntentParams): Promise<Bridge
     intents,
     externalAddress: externalAddressOverride,
     deadlineSeconds = 3600,
-    fastWallet,
+    signer,
+    provider,
+    networkId,
   } = params;
 
   if (!intents || intents.length === 0) {
@@ -308,22 +313,42 @@ export async function executeIntent(params: ExecuteIntentParams): Promise<Bridge
   }
 
   const tokenId = hexToUint8Array(tokenFastTokenId);
+  const publicKey = await signer.getPublicKey();
+  const fastAddress = await signer.getFastAddress();
 
   // Step 1: Transfer tokens to bridge address on Fast network
-  const transferResult = await fastWallet.submit({
-    claim: {
-      TokenTransfer: {
-        token_id: tokenId,
-        recipient: fastAddressToBytes(fastBridgeAddress),
-        amount: amountToHex(amount),
-        user_data: null,
-      },
-    },
+  const accountInfo1 = await provider.getAccountInfo({
+    address: publicKey,
+    tokenBalancesFilter: null,
+    stateKeyFilter: null,
+    certificateByNonce: null,
   });
 
+  const transferEnvelope = await new TransactionBuilder({
+    networkId: networkId as any,
+    signer,
+    nonce: accountInfo1.nextNonce,
+  })
+    .addTokenTransfer({
+      tokenId,
+      recipient: fastAddressToBytes(fastBridgeAddress),
+      amount: BigInt(amount),
+      userData: null,
+    })
+    .sign();
+
+  const transferResult = await provider.submitTransaction(transferEnvelope);
+  if (transferResult.type !== 'Success') {
+    throw new FastError('TX_FAILED', `Token transfer submission incomplete: ${transferResult.type}`, {
+      note: 'The transfer transaction was not fully confirmed. Try again.',
+    });
+  }
+
   // Step 2: Cross-sign the transfer certificate
-  const transferCrossSign = await evmSign(transferResult.certificate, crossSignUrl);
-  const transferFastTxId = transferResult.txHash as `0x${string}`;
+  const transferCrossSign = await evmSign(transferResult.value, crossSignUrl);
+
+  // Derive the Fast tx ID from cross-sign bytes[32:64] — this is the canonical transaction hash
+  const transferFastTxId = toHex(new Uint8Array(transferCrossSign.transaction.slice(32, 64))) as `0x${string}`;
 
   // Step 3: Build and encode the intent claim
   const deadline = BigInt(Math.floor(Date.now() / 1000) + deadlineSeconds);
@@ -350,21 +375,38 @@ export async function executeIntent(params: ExecuteIntentParams): Promise<Bridge
   const intentBytes = hexToUint8Array(intentClaimEncoded);
 
   // Step 4: Submit intent claim on Fast network
-  const intentResult = await fastWallet.submit({
-    claim: {
-      ExternalClaim: {
-        claim: {
-          verifier_committee: [] as Uint8Array[],
-          verifier_quorum: 0,
-          claim_data: Array.from(intentBytes),
-        },
-        signatures: [] as Array<[Uint8Array, Uint8Array]>,
-      },
-    },
+  const accountInfo2 = await provider.getAccountInfo({
+    address: publicKey,
+    tokenBalancesFilter: null,
+    stateKeyFilter: null,
+    certificateByNonce: null,
   });
 
+  const intentEnvelope = await new TransactionBuilder({
+    networkId: networkId as any,
+    signer,
+    nonce: accountInfo2.nextNonce,
+  })
+    .addExternalClaim({
+      claim: {
+        verifierCommittee: [],
+        verifierQuorum: 0,
+        claimData: intentBytes,
+      },
+      signatures: [],
+    })
+    .sign();
+
+  const intentResult = await provider.submitTransaction(intentEnvelope);
+  if (intentResult.type !== 'Success') {
+    throw new FastError('TX_FAILED', `Intent claim submission incomplete: ${intentResult.type}`, {
+      note: 'The intent claim transaction was not fully confirmed. Try again.',
+    });
+  }
+
   // Step 5: Cross-sign the intent certificate
-  const intentCrossSign = await evmSign(intentResult.certificate, crossSignUrl);
+  const intentCrossSign = await evmSign(intentResult.value, crossSignUrl);
+  const intentFastTxId = toHex(new Uint8Array(intentCrossSign.transaction.slice(32, 64))) as `0x${string}`;
 
   // Step 6: Resolve external address and submit to relayer
   const externalAddress = resolveExternalAddress(intents, externalAddressOverride);
@@ -379,14 +421,14 @@ export async function executeIntent(params: ExecuteIntentParams): Promise<Bridge
   const relayerBody = {
     encoded_transfer_claim: Array.from(new Uint8Array(transferCrossSign.transaction.map(Number))),
     transfer_proof: transferCrossSign.signature,
-    transfer_fast_tx_id: transferResult.txHash,
-    transfer_claim_id: transferResult.txHash,
-    fastset_address: fastWallet.address,
+    transfer_fast_tx_id: transferFastTxId,
+    transfer_claim_id: transferFastTxId,
+    fastset_address: fastAddress,
     external_address: externalAddress,
     encoded_intent_claim: Array.from(new Uint8Array(intentCrossSign.transaction.map(Number))),
     intent_proof: intentCrossSign.signature,
-    intent_fast_tx_id: intentResult.txHash,
-    intent_claim_id: intentResult.txHash,
+    intent_fast_tx_id: intentFastTxId,
+    intent_claim_id: intentFastTxId,
     external_token_address: tokenEvmAddress,
   };
 
@@ -404,8 +446,45 @@ export async function executeIntent(params: ExecuteIntentParams): Promise<Bridge
   }
 
   return {
-    txHash: transferResult.txHash,
+    txHash: transferFastTxId,
     orderId: transferFastTxId,
     estimatedTime: '1-5 minutes',
   };
+}
+
+// ---------------------------------------------------------------------------
+// executeWithdraw (Fast → EVM simple withdrawal)
+// ---------------------------------------------------------------------------
+
+/**
+ * Withdraw tokens from the Fast network to an EVM address.
+ *
+ * This is a convenience wrapper around executeIntent that builds a
+ * DynamicTransfer intent automatically.
+ *
+ * @example
+ * ```ts
+ * import { Signer, FastProvider } from '@fastxyz/fast-sdk';
+ *
+ * const signer = new Signer(privateKeyHex);
+ * const provider = new FastProvider({ rpcUrl: 'https://proxy.fast.xyz' });
+ *
+ * const result = await executeWithdraw({
+ *   fastBridgeAddress: 'fast1...',
+ *   relayerUrl: 'https://...',
+ *   crossSignUrl: 'https://...',
+ *   tokenEvmAddress: '0x...',
+ *   tokenFastTokenId: 'abc123...',
+ *   amount: '1000000',
+ *   receiverEvmAddress: '0xRecipient...',
+ *   signer,
+ *   provider,
+ *   networkId: 'fast:testnet',
+ * });
+ * ```
+ */
+export async function executeWithdraw(params: ExecuteWithdrawParams): Promise<BridgeResult> {
+  const { receiverEvmAddress, tokenEvmAddress, ...rest } = params;
+  const intent = buildTransferIntent(tokenEvmAddress, receiverEvmAddress);
+  return executeIntent({ ...rest, tokenEvmAddress, intents: [intent] });
 }

--- a/packages/allset-sdk/src/deposit.ts
+++ b/packages/allset-sdk/src/deposit.ts
@@ -1,0 +1,100 @@
+import { encodeFunctionData } from 'viem';
+import { fastAddressToBytes32 } from './address.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BuildDepositTransactionParams {
+  chainId: number;
+  bridgeContract: `0x${string}`;
+  tokenAddress: `0x${string}`;
+  isNative?: boolean;
+  amount: bigint;
+  /** Receiver Fast address (fast1...) */
+  receiver: string;
+}
+
+export interface EncodeDepositCalldataParams {
+  tokenAddress: string;
+  amount: bigint;
+  receiverBytes32: `0x${string}`;
+}
+
+export interface DepositTransactionPlan {
+  chainId: number;
+  to: `0x${string}`;
+  data: `0x${string}`;
+  value: bigint;
+  receiverBytes32: `0x${string}`;
+}
+
+// ---------------------------------------------------------------------------
+// ABI
+// ---------------------------------------------------------------------------
+
+const BRIDGE_DEPOSIT_ABI = [{
+  type: 'function' as const,
+  name: 'deposit' as const,
+  inputs: [
+    { name: 'token', type: 'address' as const },
+    { name: 'amount', type: 'uint256' as const },
+    { name: 'receiver', type: 'bytes32' as const },
+  ],
+  outputs: [],
+  stateMutability: 'payable' as const,
+}];
+
+// ---------------------------------------------------------------------------
+// Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode calldata for the bridge deposit(token, amount, receiver) call.
+ */
+export function encodeDepositCalldata(params: EncodeDepositCalldataParams): `0x${string}` {
+  return encodeFunctionData({
+    abi: BRIDGE_DEPOSIT_ABI,
+    functionName: 'deposit',
+    args: [
+      params.tokenAddress as `0x${string}`,
+      params.amount,
+      params.receiverBytes32,
+    ],
+  });
+}
+
+/**
+ * Build a deposit transaction plan for bridging tokens from EVM to Fast network.
+ *
+ * All configuration values (chainId, bridgeContract, tokenAddress) must be
+ * provided by the caller — this function contains no embedded config.
+ *
+ * @example
+ * ```ts
+ * const plan = buildDepositTransaction({
+ *   chainId: 421614,
+ *   bridgeContract: '0xb536...',
+ *   tokenAddress: '0x75fa...',
+ *   amount: 1000000n,
+ *   receiver: 'fast1abc...',
+ * });
+ * // plan.to, plan.data, plan.value are ready to send via viem walletClient
+ * ```
+ */
+export function buildDepositTransaction(
+  params: BuildDepositTransactionParams,
+): DepositTransactionPlan {
+  const receiverBytes32 = fastAddressToBytes32(params.receiver);
+  return {
+    chainId: params.chainId,
+    to: params.bridgeContract,
+    data: encodeDepositCalldata({
+      tokenAddress: params.tokenAddress,
+      amount: params.amount,
+      receiverBytes32,
+    }),
+    value: params.isNative ? params.amount : 0n,
+    receiverBytes32,
+  };
+}

--- a/packages/allset-sdk/src/errors.ts
+++ b/packages/allset-sdk/src/errors.ts
@@ -1,0 +1,31 @@
+/**
+ * errors.ts — Structured error codes for AllSet SDK.
+ *
+ * Every throwable error from the SDK is a FastError with a machine-readable
+ * `code`. Agents can switch on `code` instead of parsing message strings.
+ */
+export type FastErrorCode =
+  | 'INSUFFICIENT_BALANCE'
+  | 'NETWORK_NOT_CONFIGURED'
+  | 'TX_FAILED'
+  | 'INVALID_ADDRESS'
+  | 'TOKEN_NOT_FOUND'
+  | 'INVALID_PARAMS'
+  | 'UNSUPPORTED_OPERATION'
+  | 'KEYFILE_NOT_FOUND';
+
+export class FastError extends Error {
+  readonly code: FastErrorCode;
+  readonly note: string;
+
+  constructor(code: FastErrorCode, message: string, opts?: { note?: string }) {
+    super(message);
+    this.name = 'FastError';
+    this.code = code;
+    this.note = opts?.note ?? '';
+  }
+
+  toJSON(): Record<string, unknown> {
+    return { name: this.name, code: this.code, message: this.message, note: this.note };
+  }
+}

--- a/packages/allset-sdk/src/evm-executor.ts
+++ b/packages/allset-sdk/src/evm-executor.ts
@@ -9,7 +9,7 @@ import {
   type WalletClient,
 } from 'viem';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
-import { arbitrum, arbitrumSepolia, base, sepolia } from 'viem/chains';
+import { arbitrum, arbitrumSepolia, base, mainnet as ethereum, sepolia } from 'viem/chains';
 
 /**
  * Account-compatible wallet returned by createEvmWallet().
@@ -57,6 +57,7 @@ export const ERC20_ABI = parseAbi([
 
 /** Bundled supported chain mappings */
 export const CHAIN_MAP: Record<number, Chain> = {
+  1: ethereum,
   11155111: sepolia,
   421614: arbitrumSepolia,
   42161: arbitrum,

--- a/packages/allset-sdk/src/evm-executor.ts
+++ b/packages/allset-sdk/src/evm-executor.ts
@@ -1,0 +1,111 @@
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  parseAbi,
+  type Account,
+  type Chain,
+  type PublicClient,
+  type WalletClient,
+} from 'viem';
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { arbitrum, arbitrumSepolia, base, sepolia } from 'viem/chains';
+
+/**
+ * Account-compatible wallet returned by createEvmWallet().
+ *
+ * Includes the normalized private key so generated accounts can be persisted
+ * or reconstructed by the caller.
+ */
+export type EvmAccount = Account & {
+  privateKey: `0x${string}`;
+};
+
+function normalizePrivateKey(privateKey: string): `0x${string}` {
+  return (privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`) as `0x${string}`;
+}
+
+/**
+ * Create an EVM wallet from an optional private key.
+ *
+ * @param privateKey - Optional. If omitted, generates a new random wallet.
+ *   Accepts a hex private key (64 chars, with or without 0x prefix).
+ *
+ * @returns Account-compatible object with viem signing methods and `privateKey`
+ *
+ * @example
+ * ```ts
+ * // Generate new wallet
+ * const account = createEvmWallet();
+ * console.log(account.address);    // 0x...
+ * console.log(account.privateKey); // persist this to reuse the wallet
+ *
+ * // Restore from private key
+ * const account = createEvmWallet('0x1234...64hexchars');
+ * ```
+ */
+export function createEvmWallet(privateKey?: string): EvmAccount {
+  const key = privateKey ? normalizePrivateKey(privateKey) : generatePrivateKey();
+  return Object.assign(privateKeyToAccount(key), { privateKey: key });
+}
+
+/** ERC20 ABI for allowance and approve */
+export const ERC20_ABI = parseAbi([
+  'function approve(address spender, uint256 amount) returns (bool)',
+  'function allowance(address owner, address spender) view returns (uint256)',
+]);
+
+/** Bundled supported chain mappings */
+export const CHAIN_MAP: Record<number, Chain> = {
+  11155111: sepolia,
+  421614: arbitrumSepolia,
+  42161: arbitrum,
+  8453: base,
+};
+
+/**
+ * EVM clients returned by createEvmExecutor.
+ */
+export interface EvmClients {
+  walletClient: WalletClient;
+  publicClient: PublicClient;
+}
+
+/**
+ * Create viem wallet and public clients for EVM operations.
+ *
+ * @param account - viem Account from createEvmWallet() or privateKeyToAccount()
+ * @param rpcUrl - RPC endpoint URL
+ * @param chainId - Chain ID (11155111 for Sepolia, 421614 for Arbitrum Sepolia, 8453 for Base)
+ *
+ * @example
+ * ```ts
+ * const account = createEvmWallet('0xabc123...');
+ * const { walletClient, publicClient } = createEvmExecutor(account, rpcUrl, 421614);
+ * ```
+ */
+export function createEvmExecutor(
+  account: Account,
+  rpcUrl: string,
+  chainId: number,
+): EvmClients {
+  const chain = CHAIN_MAP[chainId];
+  if (!chain) {
+    throw new Error(
+      `Unsupported EVM chain ID: ${chainId}. Supported: ${Object.keys(CHAIN_MAP).join(', ')}`,
+    );
+  }
+
+  const walletClient = createWalletClient({
+    account,
+    chain,
+    transport: http(rpcUrl),
+  });
+
+  const publicClient = createPublicClient({
+    chain,
+    transport: http(rpcUrl),
+  });
+
+  return { walletClient, publicClient };
+}

--- a/packages/allset-sdk/src/index.ts
+++ b/packages/allset-sdk/src/index.ts
@@ -1,0 +1,7 @@
+export * from './address.js';
+export * from './deposit.js';
+export * from './evm-executor.js';
+export * from './intents.js';
+export * from './bridge.js';
+export * from './types.js';
+export * from './errors.js';

--- a/packages/allset-sdk/src/intents.ts
+++ b/packages/allset-sdk/src/intents.ts
@@ -1,0 +1,154 @@
+/**
+ * intents.ts — Intent builders for AllSet external execution
+ *
+ * Intents define what actions to perform on EVM chains after
+ * transferring tokens from Fast network.
+ */
+
+import { encodeAbiParameters } from 'viem';
+import { fastAddressToBytes32 } from './address.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Intent action types supported by AllSet bridge.
+ */
+export enum IntentAction {
+  /** Generic contract call */
+  Execute = 0,
+  /** ERC-20 transfer to address */
+  DynamicTransfer = 1,
+  /** Deposit tokens back to Fast network */
+  DynamicDeposit = 2,
+  /** Cancel/revoke pending intent */
+  Revoke = 3,
+}
+
+/**
+ * An intent to execute on an EVM chain.
+ */
+export interface Intent {
+  /** The action type */
+  action: IntentAction;
+  /** ABI-encoded payload for the action */
+  payload: `0x${string}`;
+  /** Native token value (ETH) to send, 0 for ERC-20 operations */
+  value: bigint;
+}
+
+// ---------------------------------------------------------------------------
+// Intent Builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a transfer intent to send ERC-20 tokens to an address.
+ *
+ * @param token - ERC-20 token contract address
+ * @param receiver - Recipient EVM address
+ * @returns Intent for DynamicTransfer action
+ *
+ * @example
+ * ```ts
+ * const intent = buildTransferIntent(
+ *   '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d', // USDC
+ *   '0xRecipientAddress'
+ * );
+ * ```
+ */
+export function buildTransferIntent(token: string, receiver: string): Intent {
+  const payload = encodeAbiParameters(
+    [{ type: 'address' }, { type: 'address' }],
+    [token as `0x${string}`, receiver as `0x${string}`],
+  );
+  return {
+    action: IntentAction.DynamicTransfer,
+    payload,
+    value: 0n,
+  };
+}
+
+/**
+ * Build a generic execute intent for arbitrary contract calls.
+ *
+ * @param target - Target contract address
+ * @param calldata - ABI-encoded function call data
+ * @param value - Native token value to send (default: 0)
+ * @returns Intent for Execute action
+ *
+ * @example
+ * ```ts
+ * // Call a contract function
+ * const calldata = encodeFunctionData({
+ *   abi: contractAbi,
+ *   functionName: 'someFunction',
+ *   args: [arg1, arg2],
+ * });
+ * const intent = buildExecuteIntent('0xContractAddress', calldata);
+ * ```
+ */
+export function buildExecuteIntent(
+  target: string,
+  calldata: string,
+  value: bigint = 0n,
+): Intent {
+  const payload = encodeAbiParameters(
+    [{ type: 'address' }, { type: 'bytes' }],
+    [target as `0x${string}`, calldata as `0x${string}`],
+  );
+  return {
+    action: IntentAction.Execute,
+    payload,
+    value,
+  };
+}
+
+/**
+ * Build an intent to deposit tokens back to Fast network.
+ *
+ * @param token - ERC-20 token contract address on EVM
+ * @param fastReceiver - Fast network recipient address (fast1...)
+ * @returns Intent for DynamicDeposit action
+ *
+ * @example
+ * ```ts
+ * const intent = buildDepositBackIntent(
+ *   '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d', // USDC
+ *   'fast1recipientaddress...'
+ * );
+ * ```
+ */
+export function buildDepositBackIntent(
+  token: string,
+  fastReceiver: string,
+): Intent {
+  const receiverBytes = fastAddressToBytes32(fastReceiver);
+  const payload = encodeAbiParameters(
+    [{ type: 'address' }, { type: 'bytes32' }],
+    [token as `0x${string}`, receiverBytes],
+  );
+  return {
+    action: IntentAction.DynamicDeposit,
+    payload,
+    value: 0n,
+  };
+}
+
+/**
+ * Build a revoke intent to cancel pending operations.
+ *
+ * @returns Intent for Revoke action
+ *
+ * @example
+ * ```ts
+ * const intent = buildRevokeIntent();
+ * ```
+ */
+export function buildRevokeIntent(): Intent {
+  return {
+    action: IntentAction.Revoke,
+    payload: '0x',
+    value: 0n,
+  };
+}

--- a/packages/allset-sdk/src/types.ts
+++ b/packages/allset-sdk/src/types.ts
@@ -1,0 +1,77 @@
+import type { EvmClients } from './evm-executor.js';
+import type { Intent } from './intents.js';
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export interface FastWalletLike {
+  /** Sender Fast address (fast1...) */
+  readonly address: string;
+  submit(params: {
+    claim: Record<string, unknown>;
+  }): Promise<{
+    txHash: string;
+    certificate: unknown;
+  }>;
+}
+
+export interface BridgeResult {
+  txHash: string;
+  orderId: string;
+  estimatedTime?: string;
+}
+
+// ---------------------------------------------------------------------------
+// executeDeposit params
+// ---------------------------------------------------------------------------
+
+export interface ExecuteDepositParams {
+  /** EVM chain ID */
+  chainId: number;
+  /** AllSet bridge contract address on EVM */
+  bridgeContract: `0x${string}`;
+  /** ERC-20 token contract address on EVM (ignored when isNative is true) */
+  tokenAddress: `0x${string}`;
+  /** Set to true for native ETH deposits */
+  isNative?: boolean;
+  /** Amount in smallest units (e.g., '1000000' for 1 USDC) */
+  amount: string;
+  /** Sender EVM address (0x...) */
+  senderAddress: string;
+  /** Receiver Fast address (fast1...) */
+  receiverAddress: string;
+  /** viem clients from createEvmExecutor() */
+  evmClients: EvmClients;
+}
+
+// ---------------------------------------------------------------------------
+// executeIntent params
+// ---------------------------------------------------------------------------
+
+export interface ExecuteIntentParams {
+  /** AllSet bridge address on the Fast network (fast1...) */
+  fastBridgeAddress: string;
+  /** AllSet relayer URL for the destination EVM chain */
+  relayerUrl: string;
+  /** AllSet cross-sign service URL */
+  crossSignUrl: string;
+  /** Token contract address on EVM (used in relayer payload) */
+  tokenEvmAddress: string;
+  /** Token ID on the Fast network (hex string, without 0x) */
+  tokenFastTokenId: string;
+  /** Amount in smallest units (e.g., '1000000' for 1 USDC) */
+  amount: string;
+  /** Intents to execute on EVM chain after bridge */
+  intents: Intent[];
+  /**
+   * EVM address for the relayer target.
+   * Required when intents do not include a transfer recipient or execute target
+   * (e.g., for buildDepositBackIntent or buildRevokeIntent flows).
+   */
+  externalAddress?: string;
+  /** Deadline in seconds from now (default: 3600) */
+  deadlineSeconds?: number;
+  /** Fast wallet to sign transactions */
+  fastWallet: FastWalletLike;
+}

--- a/packages/allset-sdk/src/types.ts
+++ b/packages/allset-sdk/src/types.ts
@@ -1,20 +1,10 @@
+import type { Signer, FastProvider } from '@fastxyz/fast-sdk';
 import type { EvmClients } from './evm-executor.js';
 import type { Intent } from './intents.js';
 
 // ---------------------------------------------------------------------------
 // Shared types
 // ---------------------------------------------------------------------------
-
-export interface FastWalletLike {
-  /** Sender Fast address (fast1...) */
-  readonly address: string;
-  submit(params: {
-    claim: Record<string, unknown>;
-  }): Promise<{
-    txHash: string;
-    certificate: unknown;
-  }>;
-}
 
 export interface BridgeResult {
   txHash: string;
@@ -72,6 +62,39 @@ export interface ExecuteIntentParams {
   externalAddress?: string;
   /** Deadline in seconds from now (default: 3600) */
   deadlineSeconds?: number;
-  /** Fast wallet to sign transactions */
-  fastWallet: FastWalletLike;
+  /** Ed25519 signer from @fastxyz/fast-sdk */
+  signer: Signer;
+  /** Fast RPC provider from @fastxyz/fast-sdk */
+  provider: FastProvider;
+  /** Fast network ID (e.g. 'fast:testnet', 'fast:mainnet') */
+  networkId: string;
+}
+
+// ---------------------------------------------------------------------------
+// executeWithdraw params
+// ---------------------------------------------------------------------------
+
+export interface ExecuteWithdrawParams {
+  /** AllSet bridge address on the Fast network (fast1...) */
+  fastBridgeAddress: string;
+  /** AllSet relayer URL for the destination EVM chain */
+  relayerUrl: string;
+  /** AllSet cross-sign service URL */
+  crossSignUrl: string;
+  /** Token contract address on EVM */
+  tokenEvmAddress: string;
+  /** Token ID on the Fast network (hex string, without 0x) */
+  tokenFastTokenId: string;
+  /** Amount in smallest units (e.g., '1000000' for 1 USDC) */
+  amount: string;
+  /** EVM address to receive the withdrawn tokens */
+  receiverEvmAddress: string;
+  /** Deadline in seconds from now (default: 3600) */
+  deadlineSeconds?: number;
+  /** Ed25519 signer from @fastxyz/fast-sdk */
+  signer: Signer;
+  /** Fast RPC provider from @fastxyz/fast-sdk */
+  provider: FastProvider;
+  /** Fast network ID (e.g. 'fast:testnet', 'fast:mainnet') */
+  networkId: string;
 }

--- a/packages/allset-sdk/tests/sdk.test.ts
+++ b/packages/allset-sdk/tests/sdk.test.ts
@@ -1,0 +1,665 @@
+import assert from 'node:assert/strict';
+import { test, onTestFinished } from 'vitest';
+import { FastError } from '../src/errors.ts';
+import { encodeFunctionData } from 'viem';
+
+import {
+  // address
+  fastAddressToBytes32,
+  fastAddressToBytes,
+  // deposit
+  buildDepositTransaction,
+  encodeDepositCalldata,
+  // intents
+  IntentAction,
+  buildTransferIntent,
+  buildExecuteIntent,
+  buildDepositBackIntent,
+  buildRevokeIntent,
+  // evm-executor
+  createEvmWallet,
+  createEvmExecutor,
+  // bridge
+  evmSign,
+  executeDeposit,
+  executeIntent,
+} from '../src/index.ts';
+
+const FAST_ADDRESS = 'fast1rsxfj84yhsskpr6g5ll2td7pkk3dnlsfwldsmawca4922qn3dqvqsxelzv';
+const EVM_ADDRESS = '0x1234567890123456789012345678901234567890';
+const TX_HASH = `0x${'11'.repeat(32)}`;
+const BRIDGE_CONTRACT = '0xb53600976275D6f541a3B929328d07714EFA581F' as `0x${string}`;
+const TOKEN_ADDRESS = '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d' as `0x${string}`;
+const FAST_BRIDGE_ADDRESS = 'fast1tkmtqxulhnzeeg9zhuwxy3x95wr7waytm9cq40ndf7tkuwwcc6jseg24j8';
+const RELAY_URL = 'https://testnet.allset.fast.xyz/arbitrum-sepolia/relayer';
+const CROSS_SIGN_URL = 'https://testnet.cross-sign.allset.fast.xyz';
+const TOKEN_FAST_ID = 'd73a0679a2be46981e2a8aedecd951c8b6690e7d5f8502b34ed3ff4cc2163b46';
+
+const MOCK_CROSS_SIGN_TX = [
+  ...Array(32).fill(0),
+  ...Array(32).fill(0x11),
+];
+
+// ---------------------------------------------------------------------------
+// Entrypoint Tests
+// ---------------------------------------------------------------------------
+
+test('single entrypoint exposes all public API', () => {
+  assert.equal(typeof fastAddressToBytes32, 'function');
+  assert.equal(typeof buildDepositTransaction, 'function');
+  assert.equal(typeof buildTransferIntent, 'function');
+  assert.equal(typeof createEvmWallet, 'function');
+  assert.equal(typeof executeDeposit, 'function');
+  assert.equal(typeof executeIntent, 'function');
+  assert.equal(typeof evmSign, 'function');
+});
+
+test('removed APIs are no longer exported', async () => {
+  const mod = await import('../src/index.ts') as Record<string, unknown>;
+  assert.equal('AllSetProvider' in mod, false);
+  assert.equal('executeBridge' in mod, false);
+  assert.equal('resolveDepositRoute' in mod, false);
+  assert.equal('getChainConfig' in mod, false);
+  assert.equal('getTokenConfig' in mod, false);
+  assert.equal('loadNetworksConfig' in mod, false);
+  assert.equal('getAllSetDir' in mod, false);
+  assert.equal('initUserConfig' in mod, false);
+});
+
+// ---------------------------------------------------------------------------
+// Address Tests
+// ---------------------------------------------------------------------------
+
+test('fastAddressToBytes32 converts a Fast address to bytes32', () => {
+  assert.equal(
+    fastAddressToBytes32(FAST_ADDRESS),
+    '0x1c0c991ea4bc21608f48a7fea5b7c1b5a2d9fe0977db0df5d8ed4aa502716818',
+  );
+});
+
+test('fastAddressToBytes32 rejects invalid Fast addresses', () => {
+  assert.throws(
+    () => fastAddressToBytes32('fast1invalid'),
+    /Invalid Fast address "fast1invalid"/,
+  );
+});
+
+test('fastAddressToBytes returns a 32-byte Uint8Array', () => {
+  const bytes = fastAddressToBytes(FAST_ADDRESS);
+  assert.equal(bytes.length, 32);
+  assert.ok(bytes instanceof Uint8Array);
+});
+
+// ---------------------------------------------------------------------------
+// Deposit Transaction Tests
+// ---------------------------------------------------------------------------
+
+test('encodeDepositCalldata matches deposit(address,uint256,bytes32) ABI encoding', () => {
+  const receiverBytes32 = fastAddressToBytes32(FAST_ADDRESS);
+  const expected = encodeFunctionData({
+    abi: [{
+      type: 'function' as const,
+      name: 'deposit' as const,
+      inputs: [
+        { name: 'token', type: 'address' as const },
+        { name: 'amount', type: 'uint256' as const },
+        { name: 'receiver', type: 'bytes32' as const },
+      ],
+      outputs: [],
+      stateMutability: 'payable' as const,
+    }],
+    functionName: 'deposit',
+    args: [TOKEN_ADDRESS, 1_000_000n, receiverBytes32],
+  });
+
+  assert.equal(
+    encodeDepositCalldata({ tokenAddress: TOKEN_ADDRESS, amount: 1_000_000n, receiverBytes32 }),
+    expected,
+  );
+});
+
+test('buildDepositTransaction returns correct plan', () => {
+  const plan = buildDepositTransaction({
+    chainId: 421614,
+    bridgeContract: BRIDGE_CONTRACT,
+    tokenAddress: TOKEN_ADDRESS,
+    amount: 1_000_000n,
+    receiver: FAST_ADDRESS,
+  });
+
+  assert.equal(plan.chainId, 421614);
+  assert.equal(plan.to, BRIDGE_CONTRACT);
+  assert.equal(plan.value, 0n);
+  assert.ok(plan.data.startsWith('0x'));
+  assert.ok(plan.receiverBytes32.startsWith('0x'));
+});
+
+test('buildDepositTransaction with isNative sets value to amount', () => {
+  const plan = buildDepositTransaction({
+    chainId: 421614,
+    bridgeContract: BRIDGE_CONTRACT,
+    tokenAddress: TOKEN_ADDRESS,
+    isNative: true,
+    amount: 1_000_000n,
+    receiver: FAST_ADDRESS,
+  });
+
+  assert.equal(plan.value, 1_000_000n);
+});
+
+test('buildDepositTransaction rejects invalid Fast receiver address', () => {
+  assert.throws(
+    () => buildDepositTransaction({
+      chainId: 421614,
+      bridgeContract: BRIDGE_CONTRACT,
+      tokenAddress: TOKEN_ADDRESS,
+      amount: 1_000_000n,
+      receiver: 'notavalidaddress',
+    }),
+    /Invalid Fast address/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Intent Builder Tests
+// ---------------------------------------------------------------------------
+
+test('buildTransferIntent creates correct DynamicTransfer intent', () => {
+  const intent = buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS);
+  assert.equal(intent.action, IntentAction.DynamicTransfer);
+  assert.ok(intent.payload.startsWith('0x'));
+  assert.equal(intent.value, 0n);
+});
+
+test('buildExecuteIntent creates correct Execute intent with value', () => {
+  const intent = buildExecuteIntent(TOKEN_ADDRESS, '0xabcdef', 100n);
+  assert.equal(intent.action, IntentAction.Execute);
+  assert.ok(intent.payload.startsWith('0x'));
+  assert.equal(intent.value, 100n);
+});
+
+test('buildExecuteIntent defaults value to 0', () => {
+  const intent = buildExecuteIntent(TOKEN_ADDRESS, '0xabcdef');
+  assert.equal(intent.value, 0n);
+});
+
+test('buildDepositBackIntent creates correct DynamicDeposit intent', () => {
+  const intent = buildDepositBackIntent(TOKEN_ADDRESS, FAST_ADDRESS);
+  assert.equal(intent.action, IntentAction.DynamicDeposit);
+  assert.ok(intent.payload.startsWith('0x'));
+  assert.equal(intent.value, 0n);
+});
+
+test('buildRevokeIntent creates correct Revoke intent', () => {
+  const intent = buildRevokeIntent();
+  assert.equal(intent.action, IntentAction.Revoke);
+  assert.equal(intent.payload, '0x');
+  assert.equal(intent.value, 0n);
+});
+
+// ---------------------------------------------------------------------------
+// EVM Executor / Wallet Tests
+// ---------------------------------------------------------------------------
+
+test('createEvmWallet generates new wallet when no args', () => {
+  const account = createEvmWallet();
+  assert.ok(account.address.startsWith('0x'));
+  assert.equal(account.address.length, 42);
+  assert.ok(account.privateKey.startsWith('0x'));
+  assert.equal(account.privateKey.length, 66);
+  assert.equal(createEvmWallet(account.privateKey).address, account.address);
+
+  const account2 = createEvmWallet();
+  assert.notEqual(account.address, account2.address);
+});
+
+test('createEvmWallet derives account from private key string', () => {
+  const privateKey = `0x${'55'.repeat(32)}`;
+  const account = createEvmWallet(privateKey);
+  assert.ok(account.address.startsWith('0x'));
+  assert.equal(account.privateKey, privateKey);
+  assert.equal(createEvmWallet(privateKey).address, account.address);
+
+  // Also works without 0x prefix
+  const account2 = createEvmWallet('55'.repeat(32));
+  assert.equal(account.address, account2.address);
+});
+
+test('createEvmExecutor rejects unsupported chain ids', () => {
+  const account = createEvmWallet(`0x${'11'.repeat(32)}`);
+  assert.throws(
+    () => createEvmExecutor(account, 'http://localhost:8545', 1),
+    /Unsupported EVM chain ID/,
+  );
+});
+
+test('createEvmExecutor returns walletClient and publicClient', () => {
+  const account = createEvmWallet(`0x${'22'.repeat(32)}`);
+  const clients = createEvmExecutor(account, 'http://localhost:8545', 421614);
+  assert.ok(clients.walletClient);
+  assert.ok(clients.publicClient);
+  assert.equal(typeof clients.walletClient.sendTransaction, 'function');
+  assert.equal(typeof clients.publicClient.readContract, 'function');
+});
+
+// ---------------------------------------------------------------------------
+// evmSign Tests
+// ---------------------------------------------------------------------------
+
+test('evmSign sends certificate to crossSignUrl and returns result', async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = '';
+
+  globalThis.fetch = async (url) => {
+    capturedUrl = String(url);
+    return Response.json({ result: { transaction: MOCK_CROSS_SIGN_TX, signature: '0xsig' } });
+  };
+  onTestFinished(() => { globalThis.fetch = originalFetch; });
+
+  const result = await evmSign({ ok: true }, CROSS_SIGN_URL);
+  assert.equal(capturedUrl, CROSS_SIGN_URL);
+  assert.deepEqual(result.transaction, MOCK_CROSS_SIGN_TX);
+  assert.equal(result.signature, '0xsig');
+});
+
+test('evmSign throws FastError on cross-sign error response', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => Response.json({ error: { message: 'Invalid certificate' } });
+  onTestFinished(() => { globalThis.fetch = originalFetch; });
+
+  await assert.rejects(
+    () => evmSign({ ok: true }, CROSS_SIGN_URL),
+    (error: unknown) => {
+      assert.ok(error instanceof FastError);
+      assert.equal((error as FastError).code, 'TX_FAILED');
+      assert.match((error as Error).message, /Cross-sign error/);
+      return true;
+    },
+  );
+});
+
+test('evmSign throws FastError on HTTP error', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response('Bad Request', { status: 400 });
+  onTestFinished(() => { globalThis.fetch = originalFetch; });
+
+  await assert.rejects(
+    () => evmSign({ ok: true }, CROSS_SIGN_URL),
+    (error: unknown) => {
+      assert.ok(error instanceof FastError);
+      assert.equal((error as FastError).code, 'TX_FAILED');
+      return true;
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// executeDeposit Tests
+// ---------------------------------------------------------------------------
+
+test('executeDeposit sends approve + deposit transaction for ERC-20', async () => {
+  let approveCallCount = 0;
+  let sentTx: { to: string; data: string; value: string } | undefined;
+
+  const mockClients = {
+    walletClient: {
+      sendTransaction: async (tx: { to: string; data: string; value: bigint }) => {
+        sentTx = { to: tx.to, data: tx.data, value: tx.value.toString() };
+        return TX_HASH;
+      },
+      writeContract: async () => {
+        approveCallCount++;
+        return TX_HASH;
+      },
+    },
+    publicClient: {
+      waitForTransactionReceipt: async () => ({ status: 'success' }),
+      readContract: async () => 0n, // allowance = 0 → triggers approve
+    },
+  };
+
+  const result = await executeDeposit({
+    chainId: 421614,
+    bridgeContract: BRIDGE_CONTRACT,
+    tokenAddress: TOKEN_ADDRESS,
+    amount: '1000000',
+    senderAddress: EVM_ADDRESS,
+    receiverAddress: FAST_ADDRESS,
+    evmClients: mockClients as any,
+  });
+
+  assert.equal(approveCallCount, 1);
+  assert.equal(sentTx?.to, BRIDGE_CONTRACT);
+  assert.equal(sentTx?.value, '0');
+  assert.equal(result.txHash, TX_HASH);
+  assert.equal(result.orderId, TX_HASH);
+});
+
+test('executeDeposit skips approve when allowance is sufficient', async () => {
+  let approveCallCount = 0;
+
+  const mockClients = {
+    walletClient: {
+      sendTransaction: async () => TX_HASH,
+      writeContract: async () => { approveCallCount++; return TX_HASH; },
+    },
+    publicClient: {
+      waitForTransactionReceipt: async () => ({ status: 'success' }),
+      readContract: async () => 2_000_000n, // allowance > amount
+    },
+  };
+
+  await executeDeposit({
+    chainId: 421614,
+    bridgeContract: BRIDGE_CONTRACT,
+    tokenAddress: TOKEN_ADDRESS,
+    amount: '1000000',
+    senderAddress: EVM_ADDRESS,
+    receiverAddress: FAST_ADDRESS,
+    evmClients: mockClients as any,
+  });
+
+  assert.equal(approveCallCount, 0);
+});
+
+test('executeDeposit throws FastError on reverted transaction', async () => {
+  const mockClients = {
+    walletClient: {
+      sendTransaction: async () => TX_HASH,
+      writeContract: async () => TX_HASH,
+    },
+    publicClient: {
+      waitForTransactionReceipt: async () => ({ status: 'reverted' }),
+      readContract: async () => 2_000_000n,
+    },
+  };
+
+  await assert.rejects(
+    () => executeDeposit({
+      chainId: 421614,
+      bridgeContract: BRIDGE_CONTRACT,
+      tokenAddress: TOKEN_ADDRESS,
+      amount: '1000000',
+      senderAddress: EVM_ADDRESS,
+      receiverAddress: FAST_ADDRESS,
+      evmClients: mockClients as any,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof FastError);
+      assert.equal((error as FastError).code, 'TX_FAILED');
+      return true;
+    },
+  );
+});
+
+test('executeDeposit throws FastError on invalid receiver address', async () => {
+  const mockClients = {
+    walletClient: { sendTransaction: async () => TX_HASH },
+    publicClient: {
+      waitForTransactionReceipt: async () => ({ status: 'success' }),
+      readContract: async () => 0n,
+    },
+  };
+
+  await assert.rejects(
+    () => executeDeposit({
+      chainId: 421614,
+      bridgeContract: BRIDGE_CONTRACT,
+      tokenAddress: TOKEN_ADDRESS,
+      amount: '1000000',
+      senderAddress: EVM_ADDRESS,
+      receiverAddress: 'notavalidaddress',
+      evmClients: mockClients as any,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof FastError);
+      assert.equal((error as FastError).code, 'INVALID_ADDRESS');
+      return true;
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// executeIntent Tests
+// ---------------------------------------------------------------------------
+
+test('executeIntent performs 2 Fast submits + 2 cross-signs + 1 relayer call', async () => {
+  const originalFetch = globalThis.fetch;
+  const urls: string[] = [];
+  const submitCalls: unknown[] = [];
+
+  globalThis.fetch = async (url, init) => {
+    urls.push(String(url));
+    if (String(url).includes('/relay')) {
+      return Response.json({ ok: true });
+    }
+    return Response.json({ result: { transaction: MOCK_CROSS_SIGN_TX, signature: '0xsig' } });
+  };
+  onTestFinished(() => { globalThis.fetch = originalFetch; });
+
+  const result = await executeIntent({
+    fastBridgeAddress: FAST_BRIDGE_ADDRESS,
+    relayerUrl: RELAY_URL,
+    crossSignUrl: CROSS_SIGN_URL,
+    tokenEvmAddress: TOKEN_ADDRESS,
+    tokenFastTokenId: TOKEN_FAST_ID,
+    amount: '1000000',
+    intents: [buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS)],
+    fastWallet: {
+      address: FAST_ADDRESS,
+      async submit(params) {
+        submitCalls.push(params);
+        return { txHash: TX_HASH, certificate: { ok: true } };
+      },
+    } as any,
+  });
+
+  assert.equal(submitCalls.length, 2);
+  assert.equal(urls.filter(u => u === CROSS_SIGN_URL).length, 2);
+  assert.equal(urls.filter(u => u.includes('/relay')).length, 1);
+  assert.equal(result.txHash, TX_HASH);
+  assert.equal(result.orderId, TX_HASH);
+});
+
+test('executeIntent uses fastBridgeAddress as recipient in TokenTransfer', async () => {
+  const originalFetch = globalThis.fetch;
+  const submitCalls: Array<{ claim: Record<string, unknown> }> = [];
+
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('/relay')) return Response.json({ ok: true });
+    return Response.json({ result: { transaction: MOCK_CROSS_SIGN_TX, signature: '0xsig' } });
+  };
+  onTestFinished(() => { globalThis.fetch = originalFetch; });
+
+  await executeIntent({
+    fastBridgeAddress: FAST_BRIDGE_ADDRESS,
+    relayerUrl: RELAY_URL,
+    crossSignUrl: CROSS_SIGN_URL,
+    tokenEvmAddress: TOKEN_ADDRESS,
+    tokenFastTokenId: TOKEN_FAST_ID,
+    amount: '1000000',
+    intents: [buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS)],
+    fastWallet: {
+      address: FAST_ADDRESS,
+      async submit(params) {
+        submitCalls.push(params as any);
+        return { txHash: TX_HASH, certificate: { ok: true } };
+      },
+    } as any,
+  });
+
+  const expectedRecipient = Array.from(fastAddressToBytes(FAST_BRIDGE_ADDRESS));
+  const tokenTransfer = (submitCalls[0].claim as any)?.TokenTransfer;
+  assert.deepEqual(Array.from(tokenTransfer?.recipient ?? []), expectedRecipient);
+});
+
+test('executeIntent sends correct relayer payload', async () => {
+  const originalFetch = globalThis.fetch;
+  let relayerBody: Record<string, unknown> | undefined;
+
+  globalThis.fetch = async (url, init) => {
+    if (String(url).includes('/relay')) {
+      relayerBody = JSON.parse(String(init?.body));
+      return Response.json({ ok: true });
+    }
+    return Response.json({ result: { transaction: MOCK_CROSS_SIGN_TX, signature: '0xsig' } });
+  };
+  onTestFinished(() => { globalThis.fetch = originalFetch; });
+
+  await executeIntent({
+    fastBridgeAddress: FAST_BRIDGE_ADDRESS,
+    relayerUrl: RELAY_URL,
+    crossSignUrl: CROSS_SIGN_URL,
+    tokenEvmAddress: TOKEN_ADDRESS,
+    tokenFastTokenId: TOKEN_FAST_ID,
+    amount: '1000000',
+    intents: [buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS)],
+    fastWallet: {
+      address: FAST_ADDRESS,
+      async submit() { return { txHash: TX_HASH, certificate: { ok: true } }; },
+    } as any,
+  });
+
+  assert.equal(relayerBody?.fastset_address, FAST_ADDRESS);
+  assert.equal(relayerBody?.external_address, EVM_ADDRESS);
+  assert.equal(relayerBody?.external_token_address, TOKEN_ADDRESS);
+});
+
+test('executeIntent infers external_address from Execute intent target', async () => {
+  const originalFetch = globalThis.fetch;
+  const contractAddress = '0x1111111111111111111111111111111111111111';
+  let relayerBody: Record<string, unknown> | undefined;
+
+  globalThis.fetch = async (url, init) => {
+    if (String(url).includes('/relay')) {
+      relayerBody = JSON.parse(String(init?.body));
+      return Response.json({ ok: true });
+    }
+    return Response.json({ result: { transaction: MOCK_CROSS_SIGN_TX, signature: '0xsig' } });
+  };
+  onTestFinished(() => { globalThis.fetch = originalFetch; });
+
+  await executeIntent({
+    fastBridgeAddress: FAST_BRIDGE_ADDRESS,
+    relayerUrl: RELAY_URL,
+    crossSignUrl: CROSS_SIGN_URL,
+    tokenEvmAddress: TOKEN_ADDRESS,
+    tokenFastTokenId: TOKEN_FAST_ID,
+    amount: '1000000',
+    intents: [buildExecuteIntent(contractAddress, '0xabcdef')],
+    fastWallet: {
+      address: FAST_ADDRESS,
+      async submit() { return { txHash: TX_HASH, certificate: { ok: true } }; },
+    } as any,
+  });
+
+  assert.equal(relayerBody?.external_address, contractAddress);
+});
+
+test('executeIntent throws FastError when no external address can be resolved', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    Response.json({ result: { transaction: MOCK_CROSS_SIGN_TX, signature: '0xsig' } });
+  onTestFinished(() => { globalThis.fetch = originalFetch; });
+
+  await assert.rejects(
+    () => executeIntent({
+      fastBridgeAddress: FAST_BRIDGE_ADDRESS,
+      relayerUrl: RELAY_URL,
+      crossSignUrl: CROSS_SIGN_URL,
+      tokenEvmAddress: TOKEN_ADDRESS,
+      tokenFastTokenId: TOKEN_FAST_ID,
+      amount: '1000000',
+      intents: [buildRevokeIntent()],
+      fastWallet: {
+        address: FAST_ADDRESS,
+        async submit() { return { txHash: TX_HASH, certificate: { ok: true } }; },
+      } as any,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof FastError);
+      assert.equal((error as FastError).code, 'INVALID_PARAMS');
+      return true;
+    },
+  );
+});
+
+test('executeIntent throws FastError when intents array is empty', async () => {
+  await assert.rejects(
+    () => executeIntent({
+      fastBridgeAddress: FAST_BRIDGE_ADDRESS,
+      relayerUrl: RELAY_URL,
+      crossSignUrl: CROSS_SIGN_URL,
+      tokenEvmAddress: TOKEN_ADDRESS,
+      tokenFastTokenId: TOKEN_FAST_ID,
+      amount: '1000000',
+      intents: [],
+      fastWallet: {
+        address: FAST_ADDRESS,
+        async submit() { return { txHash: TX_HASH, certificate: { ok: true } }; },
+      } as any,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof FastError);
+      assert.equal((error as FastError).code, 'INVALID_PARAMS');
+      return true;
+    },
+  );
+});
+
+test('executeIntent preserves upstream FastError from fastWallet.submit', async () => {
+  const upstreamError = new FastError('TX_FAILED', 'upstream failure', { note: 'keep identity' });
+
+  await assert.rejects(
+    () => executeIntent({
+      fastBridgeAddress: FAST_BRIDGE_ADDRESS,
+      relayerUrl: RELAY_URL,
+      crossSignUrl: CROSS_SIGN_URL,
+      tokenEvmAddress: TOKEN_ADDRESS,
+      tokenFastTokenId: TOKEN_FAST_ID,
+      amount: '1000000',
+      intents: [buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS)],
+      fastWallet: {
+        address: FAST_ADDRESS,
+        async submit() { throw upstreamError; },
+      } as any,
+    }),
+    (error: unknown) => {
+      assert.equal(error, upstreamError);
+      return true;
+    },
+  );
+});
+
+test('executeIntent throws FastError on relayer failure', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('/relay')) {
+      return new Response('internal error', { status: 500 });
+    }
+    return Response.json({ result: { transaction: MOCK_CROSS_SIGN_TX, signature: '0xsig' } });
+  };
+  onTestFinished(() => { globalThis.fetch = originalFetch; });
+
+  await assert.rejects(
+    () => executeIntent({
+      fastBridgeAddress: FAST_BRIDGE_ADDRESS,
+      relayerUrl: RELAY_URL,
+      crossSignUrl: CROSS_SIGN_URL,
+      tokenEvmAddress: TOKEN_ADDRESS,
+      tokenFastTokenId: TOKEN_FAST_ID,
+      amount: '1000000',
+      intents: [buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS)],
+      fastWallet: {
+        address: FAST_ADDRESS,
+        async submit() { return { txHash: TX_HASH, certificate: { ok: true } }; },
+      } as any,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof FastError);
+      assert.equal((error as FastError).code, 'TX_FAILED');
+      assert.match((error as Error).message, /Relayer request failed/);
+      return true;
+    },
+  );
+});

--- a/packages/allset-sdk/tests/sdk.test.ts
+++ b/packages/allset-sdk/tests/sdk.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test, onTestFinished } from 'vitest';
 import { FastError } from '../src/errors.ts';
 import { encodeFunctionData } from 'viem';
+import { Signer, FastProvider } from '@fastxyz/fast-sdk';
 
 import {
   // address
@@ -23,6 +24,7 @@ import {
   evmSign,
   executeDeposit,
   executeIntent,
+  executeWithdraw,
 } from '../src/index.ts';
 
 const FAST_ADDRESS = 'fast1rsxfj84yhsskpr6g5ll2td7pkk3dnlsfwldsmawca4922qn3dqvqsxelzv';
@@ -51,6 +53,7 @@ test('single entrypoint exposes all public API', () => {
   assert.equal(typeof createEvmWallet, 'function');
   assert.equal(typeof executeDeposit, 'function');
   assert.equal(typeof executeIntent, 'function');
+  assert.equal(typeof executeWithdraw, 'function');
   assert.equal(typeof evmSign, 'function');
 });
 
@@ -228,9 +231,16 @@ test('createEvmWallet derives account from private key string', () => {
 test('createEvmExecutor rejects unsupported chain ids', () => {
   const account = createEvmWallet(`0x${'11'.repeat(32)}`);
   assert.throws(
-    () => createEvmExecutor(account, 'http://localhost:8545', 1),
+    () => createEvmExecutor(account, 'http://localhost:8545', 999999),
     /Unsupported EVM chain ID/,
   );
+});
+
+test('createEvmExecutor supports ethereum mainnet (chainId 1)', () => {
+  const account = createEvmWallet(`0x${'11'.repeat(32)}`);
+  const clients = createEvmExecutor(account, 'https://mainnet.example.com', 1);
+  assert.ok(clients.walletClient);
+  assert.ok(clients.publicClient);
 });
 
 test('createEvmExecutor returns walletClient and publicClient', () => {
@@ -423,47 +433,68 @@ test('executeDeposit throws FastError on invalid receiver address', async () => 
 // executeIntent Tests
 // ---------------------------------------------------------------------------
 
+// Shared test signer/provider helpers
+const TEST_PRIVATE_KEY = `0x${'55'.repeat(32)}`;
+const testSigner = new Signer(TEST_PRIVATE_KEY);
+
+function makeMockProvider(opts: { submitError?: Error } = {}): FastProvider {
+  return {
+    getAccountInfo: async () => ({ nextNonce: 1n } as any),
+    submitTransaction: async (envelope: unknown) => {
+      if (opts.submitError) throw opts.submitError;
+      return { type: 'Success', value: { envelope, signatures: [] } };
+    },
+  } as unknown as FastProvider;
+}
+
+const BASE_INTENT_PARAMS = {
+  fastBridgeAddress: FAST_BRIDGE_ADDRESS,
+  relayerUrl: RELAY_URL,
+  crossSignUrl: CROSS_SIGN_URL,
+  tokenEvmAddress: TOKEN_ADDRESS,
+  tokenFastTokenId: TOKEN_FAST_ID,
+  amount: '1000000',
+  networkId: 'fast:testnet',
+} as const;
+
 test('executeIntent performs 2 Fast submits + 2 cross-signs + 1 relayer call', async () => {
   const originalFetch = globalThis.fetch;
   const urls: string[] = [];
   const submitCalls: unknown[] = [];
 
-  globalThis.fetch = async (url, init) => {
+  globalThis.fetch = async (url) => {
     urls.push(String(url));
-    if (String(url).includes('/relay')) {
-      return Response.json({ ok: true });
-    }
+    if (String(url).includes('/relay')) return Response.json({ ok: true });
     return Response.json({ result: { transaction: MOCK_CROSS_SIGN_TX, signature: '0xsig' } });
   };
   onTestFinished(() => { globalThis.fetch = originalFetch; });
 
+  const mockProvider = {
+    getAccountInfo: async () => ({ nextNonce: 1n } as any),
+    submitTransaction: async (envelope: unknown) => {
+      submitCalls.push(envelope);
+      return { type: 'Success', value: { envelope, signatures: [] } };
+    },
+  } as unknown as FastProvider;
+
   const result = await executeIntent({
-    fastBridgeAddress: FAST_BRIDGE_ADDRESS,
-    relayerUrl: RELAY_URL,
-    crossSignUrl: CROSS_SIGN_URL,
-    tokenEvmAddress: TOKEN_ADDRESS,
-    tokenFastTokenId: TOKEN_FAST_ID,
-    amount: '1000000',
+    ...BASE_INTENT_PARAMS,
     intents: [buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS)],
-    fastWallet: {
-      address: FAST_ADDRESS,
-      async submit(params) {
-        submitCalls.push(params);
-        return { txHash: TX_HASH, certificate: { ok: true } };
-      },
-    } as any,
+    signer: testSigner,
+    provider: mockProvider,
   });
 
   assert.equal(submitCalls.length, 2);
   assert.equal(urls.filter(u => u === CROSS_SIGN_URL).length, 2);
   assert.equal(urls.filter(u => u.includes('/relay')).length, 1);
+  // txHash is derived from cross-sign bytes[32:64] = MOCK_CROSS_SIGN_TX[32:64] = TX_HASH
   assert.equal(result.txHash, TX_HASH);
   assert.equal(result.orderId, TX_HASH);
 });
 
 test('executeIntent uses fastBridgeAddress as recipient in TokenTransfer', async () => {
   const originalFetch = globalThis.fetch;
-  const submitCalls: Array<{ claim: Record<string, unknown> }> = [];
+  const submitCalls: unknown[] = [];
 
   globalThis.fetch = async (url) => {
     if (String(url).includes('/relay')) return Response.json({ ok: true });
@@ -471,26 +502,28 @@ test('executeIntent uses fastBridgeAddress as recipient in TokenTransfer', async
   };
   onTestFinished(() => { globalThis.fetch = originalFetch; });
 
+  const mockProvider = {
+    getAccountInfo: async () => ({ nextNonce: 1n } as any),
+    submitTransaction: async (envelope: unknown) => {
+      submitCalls.push(envelope);
+      return { type: 'Success', value: { envelope, signatures: [] } };
+    },
+  } as unknown as FastProvider;
+
   await executeIntent({
-    fastBridgeAddress: FAST_BRIDGE_ADDRESS,
-    relayerUrl: RELAY_URL,
-    crossSignUrl: CROSS_SIGN_URL,
-    tokenEvmAddress: TOKEN_ADDRESS,
-    tokenFastTokenId: TOKEN_FAST_ID,
-    amount: '1000000',
+    ...BASE_INTENT_PARAMS,
     intents: [buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS)],
-    fastWallet: {
-      address: FAST_ADDRESS,
-      async submit(params) {
-        submitCalls.push(params as any);
-        return { txHash: TX_HASH, certificate: { ok: true } };
-      },
-    } as any,
+    signer: testSigner,
+    provider: mockProvider,
   });
 
+  // First submit is a TokenTransfer — verify the recipient in the signed envelope
+  const envelope = submitCalls[0] as any;
+  const tx = envelope.transaction.value; // VersionedTransaction.value = Transaction
+  const claim = tx.claim; // { type: 'TokenTransfer', value: { tokenId, recipient, ... } }
+  assert.equal(claim.type, 'TokenTransfer');
   const expectedRecipient = Array.from(fastAddressToBytes(FAST_BRIDGE_ADDRESS));
-  const tokenTransfer = (submitCalls[0].claim as any)?.TokenTransfer;
-  assert.deepEqual(Array.from(tokenTransfer?.recipient ?? []), expectedRecipient);
+  assert.deepEqual(Array.from(claim.value.recipient as Uint8Array), expectedRecipient);
 });
 
 test('executeIntent sends correct relayer payload', async () => {
@@ -507,20 +540,14 @@ test('executeIntent sends correct relayer payload', async () => {
   onTestFinished(() => { globalThis.fetch = originalFetch; });
 
   await executeIntent({
-    fastBridgeAddress: FAST_BRIDGE_ADDRESS,
-    relayerUrl: RELAY_URL,
-    crossSignUrl: CROSS_SIGN_URL,
-    tokenEvmAddress: TOKEN_ADDRESS,
-    tokenFastTokenId: TOKEN_FAST_ID,
-    amount: '1000000',
+    ...BASE_INTENT_PARAMS,
     intents: [buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS)],
-    fastWallet: {
-      address: FAST_ADDRESS,
-      async submit() { return { txHash: TX_HASH, certificate: { ok: true } }; },
-    } as any,
+    signer: testSigner,
+    provider: makeMockProvider(),
   });
 
-  assert.equal(relayerBody?.fastset_address, FAST_ADDRESS);
+  const expectedFastAddress = await testSigner.getFastAddress();
+  assert.equal(relayerBody?.fastset_address, expectedFastAddress);
   assert.equal(relayerBody?.external_address, EVM_ADDRESS);
   assert.equal(relayerBody?.external_token_address, TOKEN_ADDRESS);
 });
@@ -540,17 +567,10 @@ test('executeIntent infers external_address from Execute intent target', async (
   onTestFinished(() => { globalThis.fetch = originalFetch; });
 
   await executeIntent({
-    fastBridgeAddress: FAST_BRIDGE_ADDRESS,
-    relayerUrl: RELAY_URL,
-    crossSignUrl: CROSS_SIGN_URL,
-    tokenEvmAddress: TOKEN_ADDRESS,
-    tokenFastTokenId: TOKEN_FAST_ID,
-    amount: '1000000',
+    ...BASE_INTENT_PARAMS,
     intents: [buildExecuteIntent(contractAddress, '0xabcdef')],
-    fastWallet: {
-      address: FAST_ADDRESS,
-      async submit() { return { txHash: TX_HASH, certificate: { ok: true } }; },
-    } as any,
+    signer: testSigner,
+    provider: makeMockProvider(),
   });
 
   assert.equal(relayerBody?.external_address, contractAddress);
@@ -564,17 +584,10 @@ test('executeIntent throws FastError when no external address can be resolved', 
 
   await assert.rejects(
     () => executeIntent({
-      fastBridgeAddress: FAST_BRIDGE_ADDRESS,
-      relayerUrl: RELAY_URL,
-      crossSignUrl: CROSS_SIGN_URL,
-      tokenEvmAddress: TOKEN_ADDRESS,
-      tokenFastTokenId: TOKEN_FAST_ID,
-      amount: '1000000',
+      ...BASE_INTENT_PARAMS,
       intents: [buildRevokeIntent()],
-      fastWallet: {
-        address: FAST_ADDRESS,
-        async submit() { return { txHash: TX_HASH, certificate: { ok: true } }; },
-      } as any,
+      signer: testSigner,
+      provider: makeMockProvider(),
     }),
     (error: unknown) => {
       assert.ok(error instanceof FastError);
@@ -587,17 +600,10 @@ test('executeIntent throws FastError when no external address can be resolved', 
 test('executeIntent throws FastError when intents array is empty', async () => {
   await assert.rejects(
     () => executeIntent({
-      fastBridgeAddress: FAST_BRIDGE_ADDRESS,
-      relayerUrl: RELAY_URL,
-      crossSignUrl: CROSS_SIGN_URL,
-      tokenEvmAddress: TOKEN_ADDRESS,
-      tokenFastTokenId: TOKEN_FAST_ID,
-      amount: '1000000',
+      ...BASE_INTENT_PARAMS,
       intents: [],
-      fastWallet: {
-        address: FAST_ADDRESS,
-        async submit() { return { txHash: TX_HASH, certificate: { ok: true } }; },
-      } as any,
+      signer: testSigner,
+      provider: makeMockProvider(),
     }),
     (error: unknown) => {
       assert.ok(error instanceof FastError);
@@ -607,22 +613,15 @@ test('executeIntent throws FastError when intents array is empty', async () => {
   );
 });
 
-test('executeIntent preserves upstream FastError from fastWallet.submit', async () => {
+test('executeIntent preserves upstream error from provider', async () => {
   const upstreamError = new FastError('TX_FAILED', 'upstream failure', { note: 'keep identity' });
 
   await assert.rejects(
     () => executeIntent({
-      fastBridgeAddress: FAST_BRIDGE_ADDRESS,
-      relayerUrl: RELAY_URL,
-      crossSignUrl: CROSS_SIGN_URL,
-      tokenEvmAddress: TOKEN_ADDRESS,
-      tokenFastTokenId: TOKEN_FAST_ID,
-      amount: '1000000',
+      ...BASE_INTENT_PARAMS,
       intents: [buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS)],
-      fastWallet: {
-        address: FAST_ADDRESS,
-        async submit() { throw upstreamError; },
-      } as any,
+      signer: testSigner,
+      provider: makeMockProvider({ submitError: upstreamError }),
     }),
     (error: unknown) => {
       assert.equal(error, upstreamError);
@@ -634,26 +633,17 @@ test('executeIntent preserves upstream FastError from fastWallet.submit', async 
 test('executeIntent throws FastError on relayer failure', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (url) => {
-    if (String(url).includes('/relay')) {
-      return new Response('internal error', { status: 500 });
-    }
+    if (String(url).includes('/relay')) return new Response('internal error', { status: 500 });
     return Response.json({ result: { transaction: MOCK_CROSS_SIGN_TX, signature: '0xsig' } });
   };
   onTestFinished(() => { globalThis.fetch = originalFetch; });
 
   await assert.rejects(
     () => executeIntent({
-      fastBridgeAddress: FAST_BRIDGE_ADDRESS,
-      relayerUrl: RELAY_URL,
-      crossSignUrl: CROSS_SIGN_URL,
-      tokenEvmAddress: TOKEN_ADDRESS,
-      tokenFastTokenId: TOKEN_FAST_ID,
-      amount: '1000000',
+      ...BASE_INTENT_PARAMS,
       intents: [buildTransferIntent(TOKEN_ADDRESS, EVM_ADDRESS)],
-      fastWallet: {
-        address: FAST_ADDRESS,
-        async submit() { return { txHash: TX_HASH, certificate: { ok: true } }; },
-      } as any,
+      signer: testSigner,
+      provider: makeMockProvider(),
     }),
     (error: unknown) => {
       assert.ok(error instanceof FastError);
@@ -662,4 +652,34 @@ test('executeIntent throws FastError on relayer failure', async () => {
       return true;
     },
   );
+});
+
+// ---------------------------------------------------------------------------
+// executeWithdraw Tests
+// ---------------------------------------------------------------------------
+
+test('executeWithdraw calls executeIntent with a DynamicTransfer intent', async () => {
+  const originalFetch = globalThis.fetch;
+  let relayerBody: Record<string, unknown> | undefined;
+
+  globalThis.fetch = async (url, init) => {
+    if (String(url).includes('/relay')) {
+      relayerBody = JSON.parse(String(init?.body));
+      return Response.json({ ok: true });
+    }
+    return Response.json({ result: { transaction: MOCK_CROSS_SIGN_TX, signature: '0xsig' } });
+  };
+  onTestFinished(() => { globalThis.fetch = originalFetch; });
+
+  const result = await executeWithdraw({
+    ...BASE_INTENT_PARAMS,
+    receiverEvmAddress: EVM_ADDRESS,
+    signer: testSigner,
+    provider: makeMockProvider(),
+  });
+
+  assert.equal(relayerBody?.external_address, EVM_ADDRESS);
+  assert.equal(relayerBody?.external_token_address, TOKEN_ADDRESS);
+  assert.equal(result.txHash, TX_HASH);
+  assert.equal(result.orderId, TX_HASH);
 });

--- a/packages/allset-sdk/tsconfig.json
+++ b/packages/allset-sdk/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom"],
+    "types": ["node"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "composite": false
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,31 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
 
+  packages/allset-sdk:
+    dependencies:
+      '@fastxyz/fast-sdk':
+        specifier: workspace:*
+        version: link:../fast-sdk
+      '@mysten/bcs':
+        specifier: ^2.0.3
+        version: 2.0.3
+      '@noble/ed25519':
+        specifier: ^3.0.1
+        version: 3.0.1
+      '@noble/hashes':
+        specifier: ^2.0.1
+        version: 2.0.1
+      bech32:
+        specifier: ^2.0.0
+        version: 2.0.0
+      viem:
+        specifier: ^2.46.2
+        version: 2.47.6(typescript@6.0.2)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+
   packages/fast-schema:
     dependencies:
       '@mysten/bcs':
@@ -90,6 +115,9 @@ importers:
         version: 25.5.0
 
 packages:
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -398,8 +426,20 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/ed25519@3.0.1':
     resolution: {integrity: sha512-t/T8LuK0ym8ALQudCCQCtrRdMSxBnRgHXw+wg+YsSlE6d+on7sX3flqlSJ2mOs9xEuchM36kj9SuX5MG7pXQMA==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
@@ -637,8 +677,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   '@scure/base@2.0.0':
     resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -725,6 +774,17 @@ packages:
 
   '@vitest/utils@4.1.1':
     resolution: {integrity: sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==}
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -919,6 +979,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1055,6 +1118,11 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1231,6 +1299,14 @@ packages:
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  ox@0.14.7:
+    resolution: {integrity: sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -1534,6 +1610,14 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  viem@2.47.6:
+    resolution: {integrity: sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite@8.0.3:
     resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1626,11 +1710,25 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@babel/runtime@7.29.2': {}
 
@@ -1965,7 +2063,15 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/ed25519@3.0.1': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
 
@@ -2107,7 +2213,20 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.0':
     optional: true
 
+  '@scure/base@1.2.6': {}
+
   '@scure/base@2.0.0': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2193,6 +2312,10 @@ snapshots:
       '@vitest/pretty-format': 4.1.1
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  abitype@1.2.3(typescript@6.0.2):
+    optionalDependencies:
+      typescript: 6.0.2
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -2397,6 +2520,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.1: {}
+
   expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
@@ -2523,6 +2648,10 @@ snapshots:
   is-windows@1.0.2: {}
 
   isexe@2.0.0: {}
+
+  isows@1.0.7(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
 
   joycon@3.1.1: {}
 
@@ -2671,6 +2800,21 @@ snapshots:
       word-wrap: 1.2.5
 
   outdent@0.5.0: {}
+
+  ox@0.14.7(typescript@6.0.2):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.2)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - zod
 
   p-filter@2.1.0:
     dependencies:
@@ -2963,6 +3107,23 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  viem@2.47.6(typescript@6.0.2):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.2)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.14.7(typescript@6.0.2)
+      ws: 8.18.3
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
@@ -3013,5 +3174,7 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.18.3: {}
 
   yocto-queue@0.1.0: {}


### PR DESCRIPTION
Migrates the allset-sdk package into the fast-sdk monorepo as `packages/allset-sdk`, replacing the standalone repository. Affected files: `packages/allset-sdk/src/` (address, bridge, deposit, evm-executor, intents, types), `packages/allset-sdk/package.json`, and `packages/allset-sdk/SKILL.md`. Also adds an `executeWithdraw` function and general code quality improvements. Updates `pnpm-lock.yaml` to reflect the new workspace dependency.