### PR TITLE
[codex] Add Fast MetaMask Snap SDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This monorepo provides everything you need to build on Fast from TypeScript/Node
 
 **Start with the CLI.** It's the primary way to interact with the Fast network — all skill operations rely on it. Install it globally and use commands for accounts, balances, transfers, and x402 payments.
 
-**Use the SDK when you're building an integration.** The SDK provides the `Signer`, `FastProvider`, and `TransactionBuilder` classes for programmatic control — useful for bots, AI agents, and custom workflows.
+**Use the SDK when you're building an integration.** The SDK provides the `Signer`, `FastProvider`, `FastSnapClient`, and `TransactionBuilder` classes for programmatic control — useful for bots, AI agents, custom wallets, and browser dapps.
 
 The monorepo contains multiple packages:
 
@@ -52,7 +52,7 @@ The monorepo contains multiple packages:
 | Package | When to use it |
 | ------- | -------------- |
 | [@fastxyz/cli](app/cli/) | Terminal commands — accounts, balances, transfers, x402 payments |
-| [@fastxyz/sdk](packages/fast-sdk/) | Programmatic access — Signer, FastProvider, TransactionBuilder |
+| [@fastxyz/sdk](packages/fast-sdk/) | Programmatic access — Signer, FastProvider, FastSnapClient, TransactionBuilder |
 | [@fastxyz/allset-sdk](packages/allset-sdk/) | Cross-chain bridging — EVM ↔ Fast via AllSet |
 | [@fastxyz/x402-client](packages/x402-client/) | Pay for 402-protected APIs (auto-handles HTTP 402) |
 | [@fastxyz/x402-server](packages/x402-server/) | Protect your API routes with payment requirements |
@@ -150,7 +150,7 @@ pnpm cli --help
 
 ### Core SDK
 
-- **@fastxyz/sdk** — The main entry point for Fast network operations. Provides `Signer`, `FastProvider`, and `TransactionBuilder` for building, signing, and submitting transactions.
+- **@fastxyz/sdk** — The main entry point for Fast network operations. Provides `Signer`, `FastProvider`, `FastSnapClient`, and `TransactionBuilder` for building, signing, and submitting transactions.
 
 ### Cross-Chain (AllSet)
 

--- a/packages/fast-sdk/README.md
+++ b/packages/fast-sdk/README.md
@@ -1,7 +1,8 @@
 # @fastxyz/sdk
 
 TypeScript SDK for the Fast network. Provides a high-level API for signing
-transactions, querying the network, and converting addresses and amounts.
+transactions, querying the network, converting addresses and amounts, and
+connecting delegated browser signers such as MetaMask Snaps.
 
 ## Use Cases
 
@@ -10,6 +11,7 @@ transactions, querying the network, and converting addresses and amounts.
 - Transfer tokens on the Fast network
 - Create or burn tokens
 - Sign or verify messages with an Ed25519 key
+- Integrate a Fast-specific MetaMask Snap from a browser dapp
 - Convert between hex, bytes, and bech32m addresses
 
 **Out of scope:** Bridge flows (EVM ↔ Fast) → [`@fastxyz/allset-sdk`](../allset-sdk) · Token swaps, DEX operations, or generic EVM wallet operations
@@ -28,6 +30,7 @@ npm install @fastxyz/sdk
 | -------------------- | -------------------------------------------- |
 | `Signer`             | Holds an Ed25519 private key, signs messages |
 | `FastProvider`       | JSON-RPC client for the Fast proxy API       |
+| `FastSnapClient`     | MetaMask Snap client for delegated signing   |
 | `TransactionBuilder` | Fluent builder for all transaction types     |
 
 **Typical flow:** Create Signer → Create Provider → Get account info → Build transaction → Sign → Submit.
@@ -62,6 +65,28 @@ const provider = new FastProvider({
 ```
 
 There is no default URL — `rpcUrl` is always required.
+
+You can also override the transport when the SDK should not perform the raw
+JSON-RPC request itself:
+
+```ts
+const provider = new FastProvider({
+  rpcUrl: 'https://api.fast.xyz/proxy',
+  transport: {
+    request: async (url, method, params) => {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+      });
+
+      const json = await response.json();
+      if (json.error) throw new Error(json.error.message);
+      return json.result;
+    },
+  },
+});
+```
 
 ### 3. Check Account Info
 
@@ -152,7 +177,40 @@ const valid = await verify(sig, messageBytes, pubKey);
 const valid = await verifyTypedData(sig, bcsType, data, pubKey);
 ```
 
-### 7. Query Certificates and Token Metadata
+### 7. Connect to a Fast MetaMask Snap
+
+```ts
+import {
+  FastProvider,
+  FastSnapClient,
+  TransactionBuilder,
+} from '@fastxyz/sdk/browser';
+
+const snap = new FastSnapClient({
+  snapId: 'local:http://localhost:8081',
+});
+
+const { accounts } = await snap.connect();
+const signer = snap.getSigner(accounts[0]!.address);
+
+const provider = new FastProvider({
+  rpcUrl: 'https://api.fast.xyz/proxy',
+});
+
+const account = await provider.getAccountInfo({
+  address: await signer.getPublicKey(),
+});
+
+const envelope = await new TransactionBuilder({
+  networkId: 'fast:testnet',
+  signer,
+  nonce: account.nextNonce,
+})
+  .addLeaveCommittee()
+  .sign();
+```
+
+### 8. Query Certificates and Token Metadata
 
 ```ts
 // Get finalized transaction certificates
@@ -192,6 +250,10 @@ import { verify, verifyTypedData } from '@fastxyz/sdk';
 const valid = await verify(signature, message, publicKey);
 ```
 
+The same `TransactionBuilder` can also use delegated signers, including
+`FastSnapClient#getSigner(address)`, as long as they implement the exported
+`FastSigner` interface.
+
 ### FastProvider
 
 Typed JSON-RPC client for the Fast proxy API.
@@ -204,6 +266,23 @@ Typed JSON-RPC client for the Fast proxy API.
 | `getTransactionCertificates(params)`     | Fetch finalized certificates                |
 | `getPendingMultisigTransactions(params)` | Fetch pending multisig txs                  |
 | `faucetDrip(params)`                     | Request testnet/devnet faucet drip          |
+
+`FastProvider` also accepts an optional `transport` override for browser
+wallet integrations and tests.
+
+### FastSnapClient
+
+Typed EIP-1193 client for a Fast-specific MetaMask Snap.
+
+```ts
+const snap = new FastSnapClient({
+  snapId: 'npm:@fastxyz/metamask-snap',
+});
+
+await snap.install();
+const { accounts } = await snap.connect();
+const signer = snap.getSigner(accounts[0]!.address);
+```
 
 ### TransactionBuilder
 

--- a/packages/fast-sdk/package.json
+++ b/packages/fast-sdk/package.json
@@ -14,14 +14,19 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./browser": {
+      "import": "./dist/browser.js",
+      "types": "./dist/browser.d.ts"
+    },
     "./core": {
       "import": "./dist/core/index.js",
       "types": "./dist/core/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts src/core/index.ts --format esm --dts",
-    "dev": "tsup src/index.ts src/core/index.ts --format esm --watch --dts"
+    "build": "tsup src/index.ts src/browser.ts src/core/index.ts --format esm --dts",
+    "dev": "tsup src/index.ts src/browser.ts src/core/index.ts --format esm --watch --dts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fastxyz/schema": "workspace:*",

--- a/packages/fast-sdk/src/browser.ts
+++ b/packages/fast-sdk/src/browser.ts
@@ -1,0 +1,1 @@
+export * from "./index";

--- a/packages/fast-sdk/src/core/crypto/envelope.ts
+++ b/packages/fast-sdk/src/core/crypto/envelope.ts
@@ -6,7 +6,7 @@ import {
   VersionedTransactionFromBcs,
 } from "@fastxyz/schema";
 import { Effect, Schema } from "effect";
-import { signTypedData } from "./signing";
+import { signTypedData, verifyTypedData } from "./signing";
 
 /** Sign a VersionedTransaction with an Ed25519 private key. */
 export const signVersionedTransaction = (
@@ -21,6 +21,24 @@ export const signVersionedTransaction = (
       privateKey,
       bcsSchema.VersionedTransaction,
       bcsEncoded,
+    );
+  });
+
+/** Verify a VersionedTransaction signature against an Ed25519 public key. */
+export const verifyVersionedTransactionSignature = (
+  signature: Uint8Array,
+  transaction: VersionedTransaction,
+  publicKey: Uint8Array,
+) =>
+  Effect.gen(function* () {
+    const bcsEncoded = yield* Schema.encode(VersionedTransactionFromBcs)(
+      transaction,
+    );
+    return yield* verifyTypedData(
+      signature,
+      bcsSchema.VersionedTransaction,
+      bcsEncoded,
+      publicKey,
     );
   });
 

--- a/packages/fast-sdk/src/core/crypto/envelope.ts
+++ b/packages/fast-sdk/src/core/crypto/envelope.ts
@@ -8,20 +8,29 @@ import {
 import { Effect, Schema } from "effect";
 import { signTypedData } from "./signing";
 
+/** Sign a VersionedTransaction with an Ed25519 private key. */
+export const signVersionedTransaction = (
+  privateKey: Uint8Array,
+  transaction: VersionedTransaction,
+) =>
+  Effect.gen(function* () {
+    const bcsEncoded = yield* Schema.encode(VersionedTransactionFromBcs)(
+      transaction,
+    );
+    return yield* signTypedData(
+      privateKey,
+      bcsSchema.VersionedTransaction,
+      bcsEncoded,
+    );
+  });
+
 /** Build a signed TransactionEnvelope from a VersionedTransaction. */
 export const buildSignedEnvelope = (
   privateKey: Uint8Array,
   transaction: VersionedTransaction,
 ): Effect.Effect<TransactionEnvelope, unknown> =>
   Effect.gen(function* () {
-    const bcsEncoded = yield* Schema.encode(VersionedTransactionFromBcs)(
-      transaction,
-    );
-    const rawSig = yield* signTypedData(
-      privateKey,
-      bcsSchema.VersionedTransaction,
-      bcsEncoded,
-    );
+    const rawSig = yield* signVersionedTransaction(privateKey, transaction);
     const signature = yield* Schema.decodeUnknown(SignatureFromInput)(rawSig);
 
     return {

--- a/packages/fast-sdk/src/core/index.ts
+++ b/packages/fast-sdk/src/core/index.ts
@@ -2,6 +2,7 @@ export { domainEncode, encode, getTokenId, hash, hashHex } from "./crypto/bcs";
 export {
   buildSignedEnvelope,
   signVersionedTransaction,
+  verifyVersionedTransactionSignature,
 } from "./crypto/envelope";
 export {
   getPublicKey,

--- a/packages/fast-sdk/src/core/index.ts
+++ b/packages/fast-sdk/src/core/index.ts
@@ -1,5 +1,8 @@
 export { domainEncode, encode, getTokenId, hash, hashHex } from "./crypto/bcs";
-export { buildSignedEnvelope } from "./crypto/envelope";
+export {
+  buildSignedEnvelope,
+  signVersionedTransaction,
+} from "./crypto/envelope";
 export {
   getPublicKey,
   signMessage,
@@ -42,6 +45,10 @@ export {
 } from "./error/proxy";
 export { parseRpcError } from "./network/error";
 export { rpcCallEffect } from "./network/rpc";
+export {
+  JsonRpcFastTransport,
+  type FastTransport,
+} from "./network/transport";
 export {
   faucetDrip,
   getAccountInfo,

--- a/packages/fast-sdk/src/core/network/transport.ts
+++ b/packages/fast-sdk/src/core/network/transport.ts
@@ -1,0 +1,22 @@
+import { run } from "../run";
+import { rpcCallEffect } from "./rpc";
+
+export interface FastTransport {
+  request(
+    url: string,
+    method: string,
+    params: unknown,
+    timeoutMs?: number,
+  ): Promise<unknown>;
+}
+
+export class JsonRpcFastTransport implements FastTransport {
+  request(
+    url: string,
+    method: string,
+    params: unknown,
+    timeoutMs?: number,
+  ): Promise<unknown> {
+    return run(rpcCallEffect(url, method, params, timeoutMs));
+  }
+}

--- a/packages/fast-sdk/src/core/proxy.ts
+++ b/packages/fast-sdk/src/core/proxy.ts
@@ -18,16 +18,36 @@ import {
   TransactionEnvelopeFromRpc,
 } from "@fastxyz/schema";
 import { Effect, Schema } from "effect";
+import type { FastTransport } from "./network/transport";
 import { rpcCallEffect } from "./network/rpc";
+
+const requestEffect = (
+  transport: FastTransport | undefined,
+  rpcUrl: string,
+  method: string,
+  params: unknown,
+): Effect.Effect<unknown, unknown, never> =>
+  transport
+    ? Effect.tryPromise({
+        try: () => transport.request(rpcUrl, method, params),
+        catch: (error) => error,
+      })
+    : (rpcCallEffect(rpcUrl, method, params) as Effect.Effect<
+        unknown,
+        unknown,
+        never
+      >);
 
 /** Submit a signed transaction envelope via `proxy_submitTransaction`. */
 export const submitTransaction = (
+  transport: FastTransport | undefined,
   rpcUrl: string,
   params: TransactionEnvelope,
 ) =>
   Effect.gen(function* () {
     const wire = yield* Schema.encode(SubmitTransactionParamsFromRpc)(params);
-    const result = yield* rpcCallEffect(
+    const result = yield* requestEffect(
+      transport,
       rpcUrl,
       "proxy_submitTransaction",
       wire,
@@ -38,28 +58,43 @@ export const submitTransaction = (
   });
 
 /** Request a faucet drip via `proxy_faucetDrip`. */
-export const faucetDrip = (rpcUrl: string, params: FaucetDripParams) =>
+export const faucetDrip = (
+  transport: FastTransport | undefined,
+  rpcUrl: string,
+  params: FaucetDripParams,
+) =>
   Effect.gen(function* () {
     const wire = yield* Schema.encode(FaucetDripParamsFromRpc)(params);
-    yield* rpcCallEffect(rpcUrl, "proxy_faucetDrip", wire);
+    yield* requestEffect(transport, rpcUrl, "proxy_faucetDrip", wire);
   });
 
 /** Fetch account info via `proxy_getAccountInfo`. */
-export const getAccountInfo = (rpcUrl: string, params: GetAccountInfoParams) =>
+export const getAccountInfo = (
+  transport: FastTransport | undefined,
+  rpcUrl: string,
+  params: GetAccountInfoParams,
+) =>
   Effect.gen(function* () {
     const wire = yield* Schema.encode(GetAccountInfoParamsFromRpc)(params);
-    const result = yield* rpcCallEffect(rpcUrl, "proxy_getAccountInfo", wire);
+    const result = yield* requestEffect(
+      transport,
+      rpcUrl,
+      "proxy_getAccountInfo",
+      wire,
+    );
     return yield* Schema.decodeUnknown(AccountInfoResponseFromRpc)(result);
   });
 
 /** Fetch pending multisig transactions via `proxy_getPendingMultisigTransactions`. */
 export const getPendingMultisigTransactions = (
+  transport: FastTransport | undefined,
   rpcUrl: string,
   params: GetPendingMultisigParams,
 ) =>
   Effect.gen(function* () {
     const wire = yield* Schema.encode(GetPendingMultisigParamsFromRpc)(params);
-    const result = yield* rpcCallEffect(
+    const result = yield* requestEffect(
+      transport,
       rpcUrl,
       "proxy_getPendingMultisigTransactions",
       wire,
@@ -70,15 +105,20 @@ export const getPendingMultisigTransactions = (
   });
 
 /** Fetch token metadata via `proxy_getTokenInfo`. */
-export const getTokenInfo = (rpcUrl: string, params: GetTokenInfoParams) =>
+export const getTokenInfo = (
+  transport: FastTransport | undefined,
+  rpcUrl: string,
+  params: GetTokenInfoParams,
+) =>
   Effect.gen(function* () {
     const wire = yield* Schema.encode(GetTokenInfoParamsFromRpc)(params);
-    const result = yield* rpcCallEffect(rpcUrl, "proxy_getTokenInfo", wire);
+    const result = yield* requestEffect(transport, rpcUrl, "proxy_getTokenInfo", wire);
     return yield* Schema.decodeUnknown(TokenInfoResponseFromRpc)(result);
   });
 
 /** Fetch finalized transaction certificates via `proxy_getTransactionCertificates`. */
 export const getTransactionCertificates = (
+  transport: FastTransport | undefined,
   rpcUrl: string,
   params: GetTransactionCertificatesParams,
 ) =>
@@ -86,7 +126,8 @@ export const getTransactionCertificates = (
     const wire = yield* Schema.encode(GetTransactionCertificatesParamsFromRpc)(
       params,
     );
-    const result = yield* rpcCallEffect(
+    const result = yield* requestEffect(
+      transport,
       rpcUrl,
       "proxy_getTransactionCertificates",
       wire,

--- a/packages/fast-sdk/src/core/proxy.ts
+++ b/packages/fast-sdk/src/core/proxy.ts
@@ -18,8 +18,19 @@ import {
   TransactionEnvelopeFromRpc,
 } from "@fastxyz/schema";
 import { Effect, Schema } from "effect";
+import { parseRpcError } from "./network/error";
 import type { FastTransport } from "./network/transport";
 import { rpcCallEffect } from "./network/rpc";
+
+const isJsonRpcErrorLike = (
+  error: unknown,
+): error is { code: number; message: string; data?: unknown } =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  typeof (error as { code?: unknown }).code === "number" &&
+  "message" in error &&
+  typeof (error as { message?: unknown }).message === "string";
 
 const requestEffect = (
   transport: FastTransport | undefined,
@@ -30,7 +41,8 @@ const requestEffect = (
   transport
     ? Effect.tryPromise({
         try: () => transport.request(rpcUrl, method, params),
-        catch: (error) => error,
+        catch: (error) =>
+          isJsonRpcErrorLike(error) ? parseRpcError(error) : error,
       })
     : (rpcCallEffect(rpcUrl, method, params) as Effect.Effect<
         unknown,

--- a/packages/fast-sdk/src/index.ts
+++ b/packages/fast-sdk/src/index.ts
@@ -42,7 +42,21 @@ export {
 } from "./interface/errors";
 export type { ProviderOptions } from "./interface/provider";
 export { FastProvider } from "./interface/provider";
-export { Signer, verify, verifyTypedData } from "./interface/signer";
+export {
+  FastSnapClient,
+  type FastSnapAccount,
+  type FastSnapClientOptions,
+  type FastSnapConnectResult,
+  type FastSnapSignatureResult,
+  type FastSnapSignTransactionResult,
+  type Eip1193Provider,
+} from "./interface/snap";
+export {
+  Signer,
+  type FastSigner,
+  verify,
+  verifyTypedData,
+} from "./interface/signer";
 export {
   TransactionBuilder,
   type TransactionBuilderOptions,

--- a/packages/fast-sdk/src/interface/provider.ts
+++ b/packages/fast-sdk/src/interface/provider.ts
@@ -18,11 +18,17 @@ import {
 import { Schema } from "effect";
 import * as proxy from "../core/proxy";
 import { run } from "../core/run";
+import {
+  JsonRpcFastTransport,
+  type FastTransport,
+} from "../core/network/transport";
 
 /** Options for constructing a {@link FastProvider}. */
 export interface ProviderOptions {
   /** The URL of the Fast proxy JSON-RPC endpoint. */
   rpcUrl: string;
+  /** Optional transport override for browser wallets, tests, or custom clients. */
+  transport?: FastTransport;
 }
 
 /**
@@ -45,14 +51,21 @@ export interface ProviderOptions {
  */
 export class FastProvider {
   private readonly _rpcUrl: string;
+  private readonly _transport: FastTransport;
 
   constructor(opts: ProviderOptions) {
     this._rpcUrl = opts.rpcUrl;
+    this._transport = opts.transport ?? new JsonRpcFastTransport();
   }
 
   /** The proxy RPC URL this provider was constructed with. */
   get rpcUrl(): string {
     return this._rpcUrl;
+  }
+
+  /** The transport used for all proxy requests. */
+  get transport(): FastTransport {
+    return this._transport;
   }
 
   /**
@@ -62,13 +75,13 @@ export class FastProvider {
   async submitTransaction(
     params: TransactionEnvelope,
   ): Promise<SubmitTransactionResult> {
-    return run(proxy.submitTransaction(this._rpcUrl, params));
+    return run(proxy.submitTransaction(this._transport, this._rpcUrl, params));
   }
 
   /** Request a faucet drip for the given recipient. */
   async faucetDrip(params: FaucetDripInputParams): Promise<void> {
     const internal = Schema.decodeUnknownSync(FaucetDripInput)(params);
-    return run(proxy.faucetDrip(this._rpcUrl, internal));
+    return run(proxy.faucetDrip(this._transport, this._rpcUrl, internal));
   }
 
   /**
@@ -79,7 +92,7 @@ export class FastProvider {
     params: GetAccountInfoInputParams,
   ): Promise<AccountInfoResponse> {
     const internal = Schema.decodeUnknownSync(GetAccountInfoInput)(params);
-    return run(proxy.getAccountInfo(this._rpcUrl, internal));
+    return run(proxy.getAccountInfo(this._transport, this._rpcUrl, internal));
   }
 
   /** Fetch pending multisig transactions for the given address. */
@@ -87,7 +100,13 @@ export class FastProvider {
     params: GetPendingMultisigInputParams,
   ): Promise<readonly TransactionEnvelope[]> {
     const internal = Schema.decodeUnknownSync(GetPendingMultisigInput)(params);
-    return run(proxy.getPendingMultisigTransactions(this._rpcUrl, internal));
+    return run(
+      proxy.getPendingMultisigTransactions(
+        this._transport,
+        this._rpcUrl,
+        internal,
+      ),
+    );
   }
 
   /** Fetch metadata for one or more tokens by their IDs. */
@@ -95,7 +114,7 @@ export class FastProvider {
     params: GetTokenInfoInputParams,
   ): Promise<TokenInfoResponse> {
     const internal = Schema.decodeUnknownSync(GetTokenInfoInput)(params);
-    return run(proxy.getTokenInfo(this._rpcUrl, internal));
+    return run(proxy.getTokenInfo(this._transport, this._rpcUrl, internal));
   }
 
   /**
@@ -108,6 +127,12 @@ export class FastProvider {
     const internal = Schema.decodeUnknownSync(GetTransactionCertificatesInput)(
       params,
     );
-    return run(proxy.getTransactionCertificates(this._rpcUrl, internal));
+    return run(
+      proxy.getTransactionCertificates(
+        this._transport,
+        this._rpcUrl,
+        internal,
+      ),
+    );
   }
 }

--- a/packages/fast-sdk/src/interface/signer.ts
+++ b/packages/fast-sdk/src/interface/signer.ts
@@ -1,12 +1,20 @@
 import {
+  type VersionedTransaction,
   PrivateKeyFromInput,
   type PrivateKeyInputParams,
 } from "@fastxyz/schema";
 import type { BcsType } from "@mysten/bcs";
 import { Redacted, Schema } from "effect";
+import { signVersionedTransaction } from "../core/crypto/envelope";
 import * as signing from "../core/crypto/signing";
 import { run } from "../core/run";
 import { toFastAddress } from "./convert";
+
+export interface FastSigner {
+  getPublicKey(): Promise<Uint8Array>;
+  signMessage(message: Uint8Array): Promise<Uint8Array>;
+  signTransaction(transaction: VersionedTransaction): Promise<Uint8Array>;
+}
 
 /**
  * Ed25519 signer for Fast transactions.
@@ -22,7 +30,7 @@ import { toFastAddress } from "./convert";
  * const sig = await signer.signMessage(new TextEncoder().encode("hello"));
  * ```
  */
-export class Signer {
+export class Signer implements FastSigner {
   private readonly privateKey: Redacted.Redacted<Uint8Array>;
   private publicKey?: Uint8Array;
 
@@ -67,6 +75,15 @@ export class Signer {
   async signTypedData<T>(type: BcsType<T>, data: T): Promise<Uint8Array> {
     return run(
       signing.signTypedData(Redacted.value(this.privateKey), type, data),
+    );
+  }
+
+  /** Sign a Fast VersionedTransaction using the same domain-prefixed payload as the network. */
+  async signTransaction(
+    transaction: VersionedTransaction,
+  ): Promise<Uint8Array> {
+    return run(
+      signVersionedTransaction(Redacted.value(this.privateKey), transaction),
     );
   }
 }

--- a/packages/fast-sdk/src/interface/snap.ts
+++ b/packages/fast-sdk/src/interface/snap.ts
@@ -172,8 +172,12 @@ export class FastSnapClient {
     );
   }
 
-  async syncNonce(address: string): Promise<number | null> {
-    return this.invoke<number | null>("fast_syncNonce", { address });
+  async syncNonce(address: string): Promise<bigint | null> {
+    const result = await this.invoke<number | bigint | null>(
+      "fast_syncNonce",
+      { address },
+    );
+    return result == null ? null : BigInt(result);
   }
 
   getSigner(address: string): FastSigner {

--- a/packages/fast-sdk/src/interface/snap.ts
+++ b/packages/fast-sdk/src/interface/snap.ts
@@ -1,0 +1,195 @@
+import type {
+  AccountInfoResponse,
+  VersionedTransaction,
+} from "@fastxyz/schema";
+import type { FastSigner } from "./signer";
+import { fromHex, toHex } from "./convert";
+
+export interface Eip1193Provider {
+  request(args: {
+    method: string;
+    params?: unknown[] | Record<string, unknown>;
+  }): Promise<unknown>;
+}
+
+export interface FastSnapClientOptions {
+  snapId: string;
+  version?: string;
+  provider?: Eip1193Provider;
+}
+
+export interface FastSnapAccount {
+  address: string;
+  publicKey: string;
+}
+
+export interface FastSnapConnectResult {
+  connected: boolean;
+  accounts: readonly FastSnapAccount[];
+}
+
+export interface FastSnapSignatureResult {
+  address: string;
+  signature: string;
+}
+
+export interface FastSnapSignTransactionResult
+  extends FastSnapSignatureResult {
+  transaction: VersionedTransaction;
+}
+
+type FastSnapMethod =
+  | "fast_connect"
+  | "fast_getAccounts"
+  | "fast_createAccount"
+  | "fast_importAccount"
+  | "fast_getAccountInfo"
+  | "fast_signMessage"
+  | "fast_signTransaction"
+  | "fast_syncNonce";
+
+const getDefaultProvider = (): Eip1193Provider => {
+  const provider = (globalThis as { ethereum?: Eip1193Provider }).ethereum;
+  if (!provider) {
+    throw new Error(
+      "No EIP-1193 provider found. Pass FastSnapClientOptions.provider or use MetaMask.",
+    );
+  }
+  return provider;
+};
+
+class SnapSigner implements FastSigner {
+  constructor(
+    private readonly client: FastSnapClient,
+    private readonly address: string,
+  ) {}
+
+  async getPublicKey(): Promise<Uint8Array> {
+    const account = await this.client.getAccount(this.address);
+    return fromHex(account.publicKey);
+  }
+
+  async signMessage(message: Uint8Array): Promise<Uint8Array> {
+    const result = await this.client.signMessage({
+      address: this.address,
+      message,
+    });
+    return fromHex(result.signature);
+  }
+
+  async signTransaction(
+    transaction: VersionedTransaction,
+  ): Promise<Uint8Array> {
+    const result = await this.client.signTransaction({
+      address: this.address,
+      transaction,
+    });
+    return fromHex(result.signature);
+  }
+}
+
+export class FastSnapClient {
+  private readonly provider: Eip1193Provider;
+  private readonly snapId: string;
+  private readonly version?: string;
+
+  constructor(options: FastSnapClientOptions) {
+    this.provider = options.provider ?? getDefaultProvider();
+    this.snapId = options.snapId;
+    this.version = options.version;
+  }
+
+  async install(): Promise<void> {
+    const params = this.version
+      ? { [this.snapId]: { version: this.version } }
+      : { [this.snapId]: {} };
+
+    await this.provider.request({
+      method: "wallet_requestSnaps",
+      params,
+    });
+  }
+
+  async connect(): Promise<FastSnapConnectResult> {
+    await this.install();
+    return this.invoke<FastSnapConnectResult>("fast_connect");
+  }
+
+  async getAccounts(): Promise<readonly FastSnapAccount[]> {
+    return this.invoke<readonly FastSnapAccount[]>("fast_getAccounts");
+  }
+
+  async getAccount(address: string): Promise<FastSnapAccount> {
+    const account = (await this.getAccounts()).find(
+      (entry) => entry.address === address,
+    );
+    if (!account) {
+      throw new Error(
+        `Snap account not found: ${address}. Call getAccounts() first and use one of the returned addresses.`,
+      );
+    }
+    return account;
+  }
+
+  async createAccount(): Promise<FastSnapAccount> {
+    return this.invoke<FastSnapAccount>("fast_createAccount");
+  }
+
+  async importAccount(privateKey: string): Promise<FastSnapAccount> {
+    return this.invoke<FastSnapAccount>("fast_importAccount", { privateKey });
+  }
+
+  async getAccountInfo(address: string): Promise<AccountInfoResponse> {
+    return this.invoke<AccountInfoResponse>("fast_getAccountInfo", { address });
+  }
+
+  async signMessage(params: {
+    address: string;
+    message: string | Uint8Array;
+    encoding?: "utf8" | "hex";
+  }): Promise<FastSnapSignatureResult> {
+    const message =
+      params.message instanceof Uint8Array
+        ? toHex(params.message)
+        : params.encoding === "hex"
+          ? params.message
+          : toHex(new TextEncoder().encode(params.message));
+
+    return this.invoke<FastSnapSignatureResult>("fast_signMessage", {
+      address: params.address,
+      message,
+      encoding: "hex",
+    });
+  }
+
+  async signTransaction(params: {
+    address: string;
+    transaction: VersionedTransaction;
+  }): Promise<FastSnapSignTransactionResult> {
+    return this.invoke<FastSnapSignTransactionResult>(
+      "fast_signTransaction",
+      params,
+    );
+  }
+
+  async syncNonce(address: string): Promise<number | null> {
+    return this.invoke<number | null>("fast_syncNonce", { address });
+  }
+
+  getSigner(address: string): FastSigner {
+    return new SnapSigner(this, address);
+  }
+
+  private invoke<T>(
+    method: FastSnapMethod,
+    params?: Record<string, unknown>,
+  ): Promise<T> {
+    return this.provider.request({
+      method: "wallet_invokeSnap",
+      params: {
+        snapId: this.snapId,
+        request: { method, params },
+      },
+    }) as Promise<T>;
+  }
+}

--- a/packages/fast-sdk/src/interface/transaction.ts
+++ b/packages/fast-sdk/src/interface/transaction.ts
@@ -18,8 +18,10 @@ import type {
 import { TransactionInput } from "@fastxyz/schema";
 import { Schema } from "effect";
 import { SignatureFromInput } from "@fastxyz/schema";
+import { verifyVersionedTransactionSignature } from "../core/crypto/envelope";
 import { run } from "../core/run";
 import type { FastSigner } from "./signer";
+import { SigningError } from "../core/error/crypto";
 
 /** Options for constructing a {@link TransactionBuilder}. */
 export interface TransactionBuilderOptions {
@@ -179,6 +181,16 @@ export class TransactionBuilder {
     const type: TransactionVersion = version ?? "Release20260319";
     const versioned = { type, value: internal };
     const rawSignature = await signer.signTransaction(versioned);
+    const matchesSigner = await run(
+      verifyVersionedTransactionSignature(rawSignature, versioned, sender),
+    );
+    if (!matchesSigner) {
+      throw new SigningError({
+        cause: new Error(
+          "Signer returned a transaction signature that does not match its public key.",
+        ),
+      });
+    }
     const signature = Schema.decodeUnknownSync(SignatureFromInput)(rawSignature);
 
     return {

--- a/packages/fast-sdk/src/interface/transaction.ts
+++ b/packages/fast-sdk/src/interface/transaction.ts
@@ -17,16 +17,16 @@ import type {
 } from "@fastxyz/schema";
 import { TransactionInput } from "@fastxyz/schema";
 import { Schema } from "effect";
-import { buildSignedEnvelope } from "../core/crypto/envelope";
+import { SignatureFromInput } from "@fastxyz/schema";
 import { run } from "../core/run";
-import type { Signer } from "./signer";
+import type { FastSigner } from "./signer";
 
 /** Options for constructing a {@link TransactionBuilder}. */
 export interface TransactionBuilderOptions {
   /** Target network (e.g. `"fast:testnet"`, `"fast:mainnet"`). */
   networkId: NetworkId;
-  /** Signer whose private key will sign the transaction. */
-  signer: Signer;
+  /** Signer that provides the sender public key and transaction signature. */
+  signer: FastSigner;
   /** Sender's next nonce, typically from {@link FastProvider.getAccountInfo}. */
   nonce: NonceInput;
   /** BCS transaction version tag. Defaults to `"Release20260319"`. */
@@ -137,7 +137,7 @@ export class TransactionBuilder {
   }
 
   /** Replace the signer for the next {@link sign} call. */
-  setSigner(signer: Signer): this {
+  setSigner(signer: FastSigner): this {
     this.options = { ...this.options, signer };
     return this;
   }
@@ -161,8 +161,6 @@ export class TransactionBuilder {
     const { signer, networkId, nonce, version, archival, feeToken } =
       this.options;
     const sender = await signer.getPublicKey();
-    const privateKey = await signer.getPrivateKey();
-
     const ops = this.operations;
     const claim =
       ops.length === 1 ? ops[0]! : { type: "Batch" as const, value: ops };
@@ -180,7 +178,12 @@ export class TransactionBuilder {
     const internal = Schema.decodeUnknownSync(TransactionInput)(txInput);
     const type: TransactionVersion = version ?? "Release20260319";
     const versioned = { type, value: internal };
+    const rawSignature = await signer.signTransaction(versioned);
+    const signature = Schema.decodeUnknownSync(SignatureFromInput)(rawSignature);
 
-    return run(buildSignedEnvelope(privateKey, versioned));
+    return {
+      transaction: versioned,
+      signature: { type: "Signature" as const, value: signature },
+    };
   }
 }

--- a/packages/fast-sdk/tests/unit/provider.test.ts
+++ b/packages/fast-sdk/tests/unit/provider.test.ts
@@ -1,3 +1,5 @@
+import { AccountInfoResponseFromRpc } from "@fastxyz/schema";
+import { Schema } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FastProvider, Signer, TransactionBuilder } from "../../src/index";
 
@@ -17,6 +19,38 @@ describe("FastProvider", () => {
     it("stores rpcUrl", () => {
       const provider = new FastProvider({ rpcUrl: "http://localhost:9999" });
       expect(provider.rpcUrl).toBe("http://localhost:9999");
+    });
+
+    it("uses a custom transport when provided", async () => {
+      const wireAccountInfo = Schema.encodeSync(AccountInfoResponseFromRpc)({
+        sender: new Uint8Array(32).fill(1),
+        balance: 0n,
+        nextNonce: 7n,
+        pendingConfirmation: null,
+        requestedState: [],
+        requestedCertificates: null,
+        requestedValidatedTransaction: null,
+        tokenBalance: [],
+      });
+      const transport = {
+        request: vi.fn().mockResolvedValue(wireAccountInfo),
+      };
+
+      const provider = new FastProvider({
+        rpcUrl: "http://localhost:9999",
+        transport,
+      });
+
+      const result = await provider.getAccountInfo({
+        address: HEX_KEY_32,
+      });
+
+      expect(transport.request).toHaveBeenCalledWith(
+        "http://localhost:9999",
+        "proxy_getAccountInfo",
+        expect.any(Object),
+      );
+      expect(result.nextNonce).toBe(7n);
     });
   });
 

--- a/packages/fast-sdk/tests/unit/provider.test.ts
+++ b/packages/fast-sdk/tests/unit/provider.test.ts
@@ -2,6 +2,7 @@ import { AccountInfoResponseFromRpc } from "@fastxyz/schema";
 import { Schema } from "effect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FastProvider, Signer, TransactionBuilder } from "../../src/index";
+import { GeneralError } from "../../src/interface/errors";
 
 const HEX_KEY_32 =
   "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
@@ -51,6 +52,25 @@ describe("FastProvider", () => {
         expect.any(Object),
       );
       expect(result.nextNonce).toBe(7n);
+    });
+
+    it("normalizes JSON-RPC-shaped transport errors", async () => {
+      const provider = new FastProvider({
+        rpcUrl: "http://localhost:9999",
+        transport: {
+          request: vi.fn().mockRejectedValue({
+            code: 1,
+            message: "boom",
+            data: { GeneralError: "transport failed" },
+          }),
+        },
+      });
+
+      await expect(
+        provider.getAccountInfo({
+          address: HEX_KEY_32,
+        }),
+      ).rejects.toBeInstanceOf(GeneralError);
     });
   });
 

--- a/packages/fast-sdk/tests/unit/snap.test.ts
+++ b/packages/fast-sdk/tests/unit/snap.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  FastSnapClient,
+  type Eip1193Provider,
+} from "../../src/browser";
+import { fromHex } from "../../src/index";
+
+describe("FastSnapClient", () => {
+  it("installs and connects through an EIP-1193 provider", async () => {
+    const request = vi
+      .fn<NonNullable<Eip1193Provider["request"]>>()
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        connected: true,
+        accounts: [
+          {
+            address: "fast1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx3y2z9",
+            publicKey:
+              "1111111111111111111111111111111111111111111111111111111111111111",
+          },
+        ],
+      });
+    const provider: Eip1193Provider = { request };
+    const client = new FastSnapClient({
+      snapId: "local:http://localhost:8081",
+      provider,
+    });
+
+    const result = await client.connect();
+
+    expect(request).toHaveBeenNthCalledWith(1, {
+      method: "wallet_requestSnaps",
+      params: { "local:http://localhost:8081": {} },
+    });
+    expect(request).toHaveBeenNthCalledWith(2, {
+      method: "wallet_invokeSnap",
+      params: {
+        snapId: "local:http://localhost:8081",
+        request: { method: "fast_connect", params: undefined },
+      },
+    });
+    expect(result.connected).toBe(true);
+    expect(result.accounts).toHaveLength(1);
+  });
+
+  it("delegates message and transaction signing through the snap signer", async () => {
+    const request = vi
+      .fn<NonNullable<Eip1193Provider["request"]>>()
+      .mockResolvedValueOnce([
+        {
+          address: "fast1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx3y2z9",
+          publicKey:
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+      ])
+      .mockResolvedValueOnce({
+        address: "fast1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx3y2z9",
+        signature:
+          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      })
+      .mockResolvedValueOnce({
+        address: "fast1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx3y2z9",
+        signature:
+          "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        transaction: {
+          type: "Release20260319",
+          value: {
+            networkId: "fast:testnet",
+            sender: new Uint8Array(32).fill(1),
+            nonce: 1n,
+            timestampNanos: 1n,
+            claim: { type: "LeaveCommittee" },
+            archival: false,
+            feeToken: null,
+          },
+        },
+      });
+    const client = new FastSnapClient({
+      snapId: "local:http://localhost:8081",
+      provider: { request },
+    });
+    const signer = client.getSigner(
+      "fast1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx3y2z9",
+    );
+
+    const publicKey = await signer.getPublicKey();
+    const messageSignature = await signer.signMessage(
+      new TextEncoder().encode("hello snap"),
+    );
+    const txSignature = await signer.signTransaction({
+      type: "Release20260319",
+      value: {
+        networkId: "fast:testnet",
+        sender: new Uint8Array(32).fill(1),
+        nonce: 1n,
+        timestampNanos: 1n,
+        claim: { type: "LeaveCommittee" },
+        archival: false,
+        feeToken: null,
+      },
+    });
+
+    expect(publicKey).toEqual(fromHex("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+    expect(messageSignature).toBeInstanceOf(Uint8Array);
+    expect(messageSignature).toHaveLength(64);
+    expect(txSignature).toBeInstanceOf(Uint8Array);
+    expect(txSignature).toHaveLength(64);
+    expect(request).toHaveBeenNthCalledWith(1, {
+      method: "wallet_invokeSnap",
+      params: {
+        snapId: "local:http://localhost:8081",
+        request: { method: "fast_getAccounts", params: undefined },
+      },
+    });
+    expect(request).toHaveBeenNthCalledWith(2, {
+      method: "wallet_invokeSnap",
+      params: {
+        snapId: "local:http://localhost:8081",
+        request: {
+          method: "fast_signMessage",
+          params: {
+            address: "fast1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx3y2z9",
+            message: "0x68656c6c6f20736e6170",
+            encoding: "hex",
+          },
+        },
+      },
+    });
+    expect(request).toHaveBeenNthCalledWith(3, {
+      method: "wallet_invokeSnap",
+      params: {
+        snapId: "local:http://localhost:8081",
+        request: {
+          method: "fast_signTransaction",
+          params: {
+            address: "fast1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx3y2z9",
+            transaction: {
+              type: "Release20260319",
+              value: {
+                networkId: "fast:testnet",
+                sender: new Uint8Array(32).fill(1),
+                nonce: 1n,
+                timestampNanos: 1n,
+                claim: { type: "LeaveCommittee" },
+                archival: false,
+                feeToken: null,
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/fast-sdk/tests/unit/snap.test.ts
+++ b/packages/fast-sdk/tests/unit/snap.test.ts
@@ -151,4 +151,20 @@ describe("FastSnapClient", () => {
       },
     });
   });
+
+  it("returns syncNonce as bigint to avoid precision loss", async () => {
+    const request = vi
+      .fn<NonNullable<Eip1193Provider["request"]>>()
+      .mockResolvedValueOnce("9007199254740993");
+    const client = new FastSnapClient({
+      snapId: "local:http://localhost:8081",
+      provider: { request },
+    });
+
+    const nonce = await client.syncNonce(
+      "fast1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx3y2z9",
+    );
+
+    expect(nonce).toBe(9007199254740993n);
+  });
 });

--- a/packages/fast-sdk/tests/unit/transaction.test.ts
+++ b/packages/fast-sdk/tests/unit/transaction.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { FastSigner } from "../../src/index";
 import { Signer, TransactionBuilder } from "../../src/index";
 
 const HEX_TOKEN_ID =
@@ -364,6 +365,32 @@ describe("TransactionBuilder", () => {
       expect(envelopes[0]!.transaction.value.nonce).toBe(0n);
       expect(envelopes[1]!.transaction.value.nonce).toBe(1n);
       expect(envelopes[2]!.transaction.value.nonce).toBe(2n);
+    });
+  });
+
+  describe("delegated signing", () => {
+    it("supports non-key-owning signers that implement signTransaction", async () => {
+      const delegatedSigner: FastSigner = {
+        getPublicKey: vi.fn().mockResolvedValue(new Uint8Array(32).fill(9)),
+        signMessage: vi.fn().mockResolvedValue(new Uint8Array(64).fill(8)),
+        signTransaction: vi.fn().mockResolvedValue(new Uint8Array(64).fill(7)),
+      };
+
+      const builder = new TransactionBuilder({
+        networkId: "fast:testnet",
+        signer: delegatedSigner,
+        nonce: 5n,
+      });
+
+      builder.addLeaveCommittee();
+      const envelope = await builder.sign();
+
+      expect(delegatedSigner.getPublicKey).toHaveBeenCalledTimes(1);
+      expect(delegatedSigner.signTransaction).toHaveBeenCalledTimes(1);
+      expect(envelope.transaction.value.sender).toEqual(
+        new Uint8Array(32).fill(9),
+      );
+      expect(envelope.signature.value).toEqual(new Uint8Array(64).fill(7));
     });
   });
 

--- a/packages/fast-sdk/tests/unit/transaction.test.ts
+++ b/packages/fast-sdk/tests/unit/transaction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { FastSigner } from "../../src/index";
 import { Signer, TransactionBuilder } from "../../src/index";
+import { SigningError } from "../../src/interface/errors";
 
 const HEX_TOKEN_ID =
   "1111111111111111111111111111111111111111111111111111111111111111";
@@ -370,10 +371,15 @@ describe("TransactionBuilder", () => {
 
   describe("delegated signing", () => {
     it("supports non-key-owning signers that implement signTransaction", async () => {
+      const realSigner = new Signer(new Uint8Array(32).fill(9));
       const delegatedSigner: FastSigner = {
-        getPublicKey: vi.fn().mockResolvedValue(new Uint8Array(32).fill(9)),
+        getPublicKey: vi.fn().mockResolvedValue(await realSigner.getPublicKey()),
         signMessage: vi.fn().mockResolvedValue(new Uint8Array(64).fill(8)),
-        signTransaction: vi.fn().mockResolvedValue(new Uint8Array(64).fill(7)),
+        signTransaction: vi
+          .fn()
+          .mockImplementation((transaction) =>
+            realSigner.signTransaction(transaction),
+          ),
       };
 
       const builder = new TransactionBuilder({
@@ -388,9 +394,33 @@ describe("TransactionBuilder", () => {
       expect(delegatedSigner.getPublicKey).toHaveBeenCalledTimes(1);
       expect(delegatedSigner.signTransaction).toHaveBeenCalledTimes(1);
       expect(envelope.transaction.value.sender).toEqual(
-        new Uint8Array(32).fill(9),
+        await realSigner.getPublicKey(),
       );
-      expect(envelope.signature.value).toEqual(new Uint8Array(64).fill(7));
+      expect(envelope.signature.value).toHaveLength(64);
+    });
+
+    it("rejects delegated signers whose signature does not match the claimed public key", async () => {
+      const realSigner = new Signer(new Uint8Array(32).fill(33));
+      const wrongSigner = new Signer(new Uint8Array(32).fill(34));
+      const delegatedSigner: FastSigner = {
+        getPublicKey: vi.fn().mockResolvedValue(await realSigner.getPublicKey()),
+        signMessage: vi.fn().mockResolvedValue(new Uint8Array(64).fill(8)),
+        signTransaction: vi
+          .fn()
+          .mockImplementation((transaction) =>
+            wrongSigner.signTransaction(transaction),
+          ),
+      };
+
+      const builder = new TransactionBuilder({
+        networkId: "fast:testnet",
+        signer: delegatedSigner,
+        nonce: 6n,
+      });
+
+      builder.addLeaveCommittee();
+
+      await expect(builder.sign()).rejects.toBeInstanceOf(SigningError);
     });
   });
 


### PR DESCRIPTION
## Summary

Rebases the Fast MetaMask Snap work onto the current monorepo layout and adds the SDK-side support needed for delegated browser signing.

## What Changed

- add FastSnapClient and a new @fastxyz/sdk/browser entrypoint
- add a transport abstraction so FastProvider can use custom request adapters
- refactor transaction signing to work with delegated signers, not only raw private-key holders
- keep Signer compatible while adding the exported FastSigner interface
- add unit coverage for custom transports, delegated transaction signing, and Snap RPC flows
- update the SDK README and monorepo README to document browser Snap usage

## Why

main moved to the monorepo and released @fastxyz/sdk 1.0.1, so the original branch no longer matched the published package layout. This rebases the Snap support onto the current package structure and clears the merge conflicts on the PR.

## Validation

- pnpm --filter @fastxyz/sdk... build
- pnpm --filter @fastxyz/sdk test