### PR TITLE
ci: add manual CLI publish workflow

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,44 @@
+name: Publish CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or tag to publish from"
+        type: string
+        default: "main"
+        required: true
+      dry_run:
+        description: "Dry run (skip actual publish)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build CLI (including workspace dependencies)
+        run: pnpm --filter @fastxyz/cli... build
+
+      - name: Publish CLI
+        if: ${{ !inputs.dry_run }}
+        run: pnpm --filter @fastxyz/cli publish --access public --no-git-checks
+
+      - name: Dry run (pack only)
+        if: ${{ inputs.dry_run }}
+        run: pnpm --filter @fastxyz/cli pack --dry-run


### PR DESCRIPTION
Adds a `workflow_dispatch` workflow to manually publish `@fastxyz/cli` to npm independently of other SDK packages.

- Builds only the CLI and its workspace dependencies (`--filter @fastxyz/cli...`)
- Uses npm OIDC Trusted Publishing (no `NPM_TOKEN` secret required)
- Supports a `dry_run` option (runs `pack --dry-run` instead of publishing)
- Accepts a `ref` input to choose which branch/tag to publish from