### PR TITLE
chore: convert fast-schema and fast-sdk to ESM-only

### DIFF
--- a/packages/fast-schema/package.json
+++ b/packages/fast-schema/package.json
@@ -1,12 +1,18 @@
 {
   "name": "@fastxyz/schema",
   "version": "1.0.0",
+  "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts",
-    "dev": "tsup src/index.ts --format cjs,esm --watch --dts"
+    "build": "tsup src/index.ts --format esm --dts",
+    "dev": "tsup src/index.ts --format esm --watch --dts"
   },
   "dependencies": {
     "@mysten/bcs": "^2.0.3",

--- a/packages/fast-sdk/package.json
+++ b/packages/fast-sdk/package.json
@@ -1,24 +1,22 @@
 {
   "name": "@fastxyz/sdk",
   "version": "1.0.0",
+  "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
     "./core": {
-      "import": "./dist/core/index.mjs",
-      "require": "./dist/core/index.js",
+      "import": "./dist/core/index.js",
       "types": "./dist/core/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts src/core/index.ts --format cjs,esm --dts",
-    "dev": "tsup src/index.ts src/core/index.ts --format cjs,esm --watch --dts"
+    "build": "tsup src/index.ts src/core/index.ts --format esm --dts",
+    "dev": "tsup src/index.ts src/core/index.ts --format esm --watch --dts"
   },
   "dependencies": {
     "@fastxyz/schema": "workspace:*",

--- a/packages/fast-sdk/tests/unit/provider.test.ts
+++ b/packages/fast-sdk/tests/unit/provider.test.ts
@@ -67,8 +67,8 @@ describe("FastProvider", () => {
       );
     });
 
-    it("rejects invalid recipient length", () => {
-      expect(() =>
+    it("rejects invalid recipient length", async () => {
+      await expect(() =>
         provider.faucetDrip({ recipient: "abcd", amount: 1n, tokenId: null }),
       ).rejects.toThrow();
     });


### PR DESCRIPTION
## Summary

Convert `@fastxyz/schema` and `@fastxyz/sdk` from dual CJS+ESM builds to ESM-only.

## Problem

Both packages depend on `@mysten/bcs` v2.x which is ESM-only. The CJS build caused a Node.js `ExperimentalWarning` at runtime when `require()` attempted to load an ESM dependency:

```
ExperimentalWarning: Importing ESM module ... as CommonJS
```

## Changes

- `packages/fast-schema/package.json` — add `"type": "module"`, proper `exports` field, drop CJS from tsup build
- `packages/fast-sdk/package.json` — same: ESM-only build, updated `exports` field
- `packages/fast-sdk/tests/unit/provider.test.ts` — fix missing `await` on `expect().rejects.toThrow()` (future Vitest breakage)

## Compatibility

All internal consumers (`@fastxyz/cli`, `allset-sdk`, `x402-client`, `x402-facilitator`) already use `"type": "module"` — no changes needed downstream.