### PR TITLE
[codex] Add CLI access key lifecycle commands

### DIFF
--- a/ACCESS_KEY_IMPLEMENTATION_PLAN.md
+++ b/ACCESS_KEY_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,187 @@
+# Access Key Implementation Plan
+
+## Goal
+
+Add CLI support for FAST access keys so a user can:
+
+1. create a CLI-managed access key for an existing FAST owner account
+2. list existing access keys for that owner account
+3. revoke an access key
+4. use a CLI-managed access key for transaction signing where appropriate
+
+The resulting keys must be registered through the shared `fast-key-manager` lifecycle so they also appear in `app.fast.xyz`.
+
+## Current state
+
+- `origin/main` CLI commands currently cover `account`, `network`, `info`, `fund`, `send`, and `pay`.
+- The CLI has local storage for owner accounts, but no storage for delegated access-key material.
+- There is no access-key lifecycle command surface on `origin/main`.
+- Access-key transaction authorization primitives exist in the broader FAST codebase, but the CLI does not yet expose create/list/revoke flows.
+
+## Scope in this repo
+
+This repo should own:
+
+- CLI command design and UX
+- local persistence for CLI-managed access-key signing material
+- integration with `fast-key-manager` create/list/revoke endpoints
+- transaction signing path for CLI-managed access keys
+
+This repo should not own:
+
+- the shared registry and audit model for access keys
+- browser UI behavior in `app.fast.xyz`
+
+## Proposed command surface
+
+Add a new top-level group:
+
+```text
+fast access-key create
+fast access-key list
+fast access-key revoke
+```
+
+Optional later command:
+
+```text
+fast access-key use
+```
+
+That command is only needed if we want to set a default active delegated signer instead of selecting one per transaction.
+
+## Data model changes
+
+Add a local store for CLI-managed access keys.
+
+Minimum fields:
+
+- local id or alias
+- owner account name
+- owner account address
+- access key id
+- delegate public key
+- encrypted delegated private key or equivalent local signer handle
+- label
+- client id
+- created at
+- revoked flag cache
+
+Target areas:
+
+- `app/cli/src/db/schema.ts`
+- `app/cli/src/services/storage/*`
+
+The delegated private key must stay local to the CLI runtime. The key manager only tracks metadata, policy, and capabilities.
+
+## Command implementation
+
+### 1. `fast access-key create`
+
+Inputs:
+
+- owner account
+- label
+- client id
+- expiry
+- allowed token set
+- max spend cap
+
+Flow:
+
+1. resolve owner account and decrypt it if needed
+2. generate delegated key material locally
+3. build the access-key authorization transaction
+4. start owner approval with `fast-key-manager`
+5. obtain owner authorization using the selected signer flow
+6. submit the authorization transaction
+7. commit creation with `fast-key-manager`
+8. persist delegated key material locally
+9. print JSON and human output including `accessKeyId`
+
+### 2. `fast access-key list`
+
+Inputs:
+
+- owner account or address
+
+Flow:
+
+1. query `fast-key-manager` for access keys on the owner account
+2. join with local CLI store where possible
+3. show whether each key is locally managed by this CLI instance
+
+### 3. `fast access-key revoke`
+
+Inputs:
+
+- owner account
+- access key id
+
+Flow:
+
+1. start revoke approval with `fast-key-manager`
+2. obtain owner authorization
+3. submit revoke transaction
+4. commit revocation with `fast-key-manager`
+5. mark local key record revoked or delete it, depending on desired UX
+
+## Signing integration
+
+There are two distinct signer roles:
+
+- owner signer for access-key authorization and revocation
+- delegated signer for later transaction execution
+
+The CLI must keep these separate.
+
+Recommended first milestone:
+
+- support lifecycle commands first
+- do not change `fast send` yet
+
+Recommended second milestone:
+
+- add an explicit `--access-key <id>` path to `fast send`
+- use locally stored delegated key material when that flag is present
+
+This keeps the initial rollout smaller and avoids silently changing current account behavior.
+
+## File targets
+
+Expected implementation areas:
+
+- `app/cli/src/cli.ts`
+- `app/cli/src/commands/index.ts`
+- `app/cli/src/commands/access-key/create.ts`
+- `app/cli/src/commands/access-key/list.ts`
+- `app/cli/src/commands/access-key/revoke.ts`
+- `app/cli/src/services/storage/`
+- `app/cli/src/services/api/`
+- `app/cli/src/db/schema.ts`
+- `app/cli/README.md`
+
+## Validation
+
+Add tests for:
+
+- schema persistence for local delegated keys
+- create command happy path
+- list command with local and remote-only keys
+- revoke command happy path
+- JSON output envelope
+- failure modes for missing owner account, approval failure, network failure, and unknown access key
+
+## Dependency order
+
+1. finalize `fast-key-manager` metadata contract if any additions are needed
+2. add CLI storage and command surface
+3. wire CLI to shared key-manager endpoints
+4. add CLI send-with-access-key support
+5. update docs
+
+## Open questions
+
+1. Should CLI-managed access keys get a distinct `clientId`, or should they default to `app.fast.xyz` for compatibility?
+2. Should revoked keys remain in local storage for audit/history, or be removed?
+3. Should `fast send` accept both owner signer and access-key signer on the same command, or should access-key sends live under a separate subcommand?

--- a/app/cli/README.md
+++ b/app/cli/README.md
@@ -75,6 +75,56 @@ These options work with every command:
 
 ## Commands
 
+### `fast access-key create`
+
+Create and register a CLI-managed access key for the selected owner account.
+
+```bash
+fast access-key create --account my-account
+```
+
+**Options:**
+- `--account <name>` — Owner account to authorize the access key
+- `--label <text>` — Access-key label (defaults to `FAST CLI access key`)
+- `--client-id <id>` — Client scope recorded in policy metadata (defaults to `app.fast.xyz`)
+- `--expires-in-hours <n>` — Expiry window in hours
+- `--max-total-spend-usdc <amount>` — Total USDC spend cap
+
+The CLI generates delegated signer material locally, submits the on-chain authorization with the owner account, and registers the resulting metadata with the FAST key manager so the key also appears in `app.fast.xyz`.
+
+---
+
+### `fast access-key list`
+
+List access keys for the selected owner account and show whether this CLI instance has local signer material for each key.
+
+```bash
+fast access-key list --account my-account
+```
+
+**Options:**
+- `--account <name>` — Owner account to inspect
+
+---
+
+### `fast access-key revoke <access-key-id>`
+
+Revoke an access key with the selected owner account.
+
+```bash
+fast access-key revoke 0xabc123... --account my-account
+```
+
+**Positional arguments:**
+- `<access-key-id>` — 32-byte access key identifier
+
+**Options:**
+- `--account <name>` — Owner account that owns the access key
+
+Revocation is submitted on-chain, mirrored to the key manager, and removes locally stored signer material for that key from this CLI instance.
+
+---
+
 ### `fast account create`
 
 Create a new Ed25519 account and store it in the local keystore.
@@ -366,7 +416,7 @@ The CLI stores data in `~/.fast/`:
 
 ```
 ~/.fast/
-  fast.db          # SQLite database (accounts, networks, history, encrypted keys)
+  fast.db          # SQLite database (accounts, networks, history, encrypted keys, access-key material)
 ```
 
 ## Environment Variables
@@ -374,6 +424,7 @@ The CLI stores data in `~/.fast/`:
 | Variable | Description |
 |----------|-------------|
 | `FAST_PASSWORD` | Default keystore password (avoids interactive prompt) |
+| `FAST_KEY_MANAGER_URL` | Override the key-manager base URL for `access-key` commands |
 
 ## Examples
 
@@ -391,6 +442,19 @@ fast info balance --account my-account
 
 # 4. Send tokens to someone
 fast send fast1recipient... 1.25 --account my-account --token USDC
+```
+
+### Provision a CLI access key
+
+```bash
+# Create and register a key that also appears in app.fast.xyz
+fast access-key create --account my-account --label "Automation signer"
+
+# Inspect all keys for the account
+fast access-key list --account my-account
+
+# Revoke a key when it is no longer needed
+fast access-key revoke 0xabc123... --account my-account
 ```
 
 ### Pay for an x402-protected API

--- a/app/cli/drizzle/0001_access_keys.sql
+++ b/app/cli/drizzle/0001_access_keys.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `access_keys` (
+	`access_key_id` text PRIMARY KEY NOT NULL,
+	`owner_account_name` text NOT NULL,
+	`owner_fast_address` text NOT NULL,
+	`network` text NOT NULL,
+	`delegate_public_key` text NOT NULL,
+	`encrypted_private_key` blob NOT NULL,
+	`encrypted` integer DEFAULT true NOT NULL,
+	`label` text,
+	`client_id` text NOT NULL,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_access_keys_owner_network` ON `access_keys` (`owner_fast_address`,`network`);

--- a/app/cli/drizzle/meta/_journal.json
+++ b/app/cli/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775534838047,
       "tag": "0000_colossal_blizzard",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776229200000,
+      "tag": "0001_access_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/app/cli/package.json
+++ b/app/cli/package.json
@@ -28,12 +28,14 @@
     "@effect/printer": "^0.49.0",
     "@effect/printer-ansi": "^0.49.0",
     "@effect/typeclass": "^0.40.0",
+    "@mysten/bcs": "^2.0.3",
     "@optique/core": "^0.10.7",
     "bech32": "^2.0.0",
     "better-sqlite3": "^12.8.0",
     "cli-table3": "^0.6.5",
     "drizzle-orm": "^0.45.2",
     "effect": "^3.21.0",
+    "json-with-bigint": "^3.5.8",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/app/cli/src/app.ts
+++ b/app/cli/src/app.ts
@@ -2,12 +2,14 @@ import { Effect, Layer, type Option } from "effect";
 import { type ClientError, InternalError } from "./errors/index.js";
 import { AllSetLive } from "./services/api/allset.js";
 import { FastRpcLive } from "./services/api/fast.js";
+import { KeyManagerApiLive } from "./services/api/key-manager.js";
 import { X402Service } from "./services/api/x402.js";
 import { AppConfigLive } from "./services/config/app.js";
 import { makeClientConfigLayer } from "./services/config/client.js";
 import { Output, OutputLive } from "./services/output.js";
 import { PromptLive } from "./services/prompt.js";
 import { AccountStore } from "./services/storage/account.js";
+import { AccessKeyStore } from "./services/storage/access-key.js";
 import { DatabaseLive } from "./services/storage/database.js";
 import { HistoryStore } from "./services/storage/history.js";
 import { NetworkConfigService } from "./services/storage/network.js";
@@ -42,7 +44,9 @@ export const makeAppLayer = (opts: GlobalOptions) => {
     NetworkConfigService.Default,
     HistoryStore.Default,
     AccountStore.Default,
+    AccessKeyStore.Default,
     X402Service.Default,
+    KeyManagerApiLive,
   ).pipe(Layer.provide(foundation));
 
   // Services that depend on tier1

--- a/app/cli/src/cli.ts
+++ b/app/cli/src/cli.ts
@@ -157,6 +157,70 @@ const accountGroup = command(
 );
 
 // ---------------------------------------------------------------------------
+// Access key commands
+// ---------------------------------------------------------------------------
+
+const accessKeyCreateParser = command(
+  "create",
+  object({
+    cmd: constant("access-key-create" as const),
+    label: optional(
+      option("--label", string({ metavar: "LABEL" }), {
+        description: message`Label shown in wallet UIs`,
+      }),
+    ),
+    clientId: optional(
+      option("--client-id", string({ metavar: "CLIENT_ID" }), {
+        description: message`Policy client ID (defaults to app.fast.xyz)`,
+      }),
+    ),
+    token: optional(
+      option("--token", string({ metavar: "TOKEN" }), {
+        description: message`Allowed token symbol (defaults to USDC)`,
+      }),
+    ),
+    expiresInHours: withDefault(
+      option("--expires-in-hours", integer(), {
+        description: message`Lifetime in hours`,
+      }),
+      24 * 30,
+    ),
+    maxTotalSpendUsdc: withDefault(
+      option("--max-total-spend-usdc", string({ metavar: "AMOUNT" }), {
+        description: message`Spend cap in whole-token units`,
+      }),
+      "250.00",
+    ),
+  }),
+  { description: message`Create and register a CLI-managed access key` },
+);
+
+const accessKeyListParser = command(
+  "list",
+  object({
+    cmd: constant("access-key-list" as const),
+  }),
+  { description: message`List access keys for the selected account` },
+);
+
+const accessKeyRevokeParser = command(
+  "revoke",
+  object({
+    cmd: constant("access-key-revoke" as const),
+    accessKeyId: argument(string({ metavar: "ACCESS_KEY_ID" }), {
+      description: message`Access key ID to revoke`,
+    }),
+  }),
+  { description: message`Revoke an access key using the selected owner account` },
+);
+
+const accessKeyGroup = command(
+  "access-key",
+  or(accessKeyCreateParser, accessKeyListParser, accessKeyRevokeParser),
+  { description: message`Manage FAST access keys` },
+);
+
+// ---------------------------------------------------------------------------
 // Network commands
 // ---------------------------------------------------------------------------
 
@@ -439,7 +503,7 @@ const payParser = command(
 // Root parser — merge global options with the command union
 // ---------------------------------------------------------------------------
 
-const commands = or(accountGroup, networkGroup, infoGroup, sendParser, fundGroup, payParser);
+const commands = or(accessKeyGroup, accountGroup, networkGroup, infoGroup, sendParser, fundGroup, payParser);
 
 export const parser = merge(globalOptions, commands);
 
@@ -448,6 +512,9 @@ export const parser = merge(globalOptions, commands);
 // ---------------------------------------------------------------------------
 
 export type AccountCreateArgs = InferValue<typeof accountCreateParser>;
+export type AccessKeyCreateArgs = InferValue<typeof accessKeyCreateParser>;
+export type AccessKeyListArgs = InferValue<typeof accessKeyListParser>;
+export type AccessKeyRevokeArgs = InferValue<typeof accessKeyRevokeParser>;
 export type AccountImportArgs = InferValue<typeof accountImportParser>;
 export type AccountListArgs = InferValue<typeof accountListParser>;
 export type AccountSetDefaultArgs = InferValue<typeof accountSetDefaultParser>;

--- a/app/cli/src/commands/access-key/create.ts
+++ b/app/cli/src/commands/access-key/create.ts
@@ -1,0 +1,213 @@
+import { fromFastAddress, Signer, toHex } from "@fastxyz/sdk";
+import { Effect } from "effect";
+import type { AccessKeyCreateArgs } from "../../cli.js";
+import { TransactionFailedError } from "../../errors/index.js";
+import {
+  buildAuthorizeAccessKeyEnvelope,
+  type AccessKeyPermissionName,
+} from "../../services/access-key-protocol.js";
+import {
+  decimalToBaseUnits,
+  DEFAULT_ACCESS_KEY_CLIENT_ID,
+  DEFAULT_ACCESS_KEY_LABEL,
+  submitRawTransaction,
+  extractSuccessCertificate,
+  nowNanos,
+} from "../../services/access-key-runtime.js";
+import { KeyManagerApi } from "../../services/api/key-manager.js";
+import { Output } from "../../services/output.js";
+import { Prompt } from "../../services/prompt.js";
+import { AccessKeyStore } from "../../services/storage/access-key.js";
+import { AccountStore } from "../../services/storage/account.js";
+import { NetworkConfigService } from "../../services/storage/network.js";
+import { FastRpc } from "../../services/api/fast.js";
+import { ClientConfig } from "../../services/config/client.js";
+import { resolveToken } from "../../services/token-resolver.js";
+import type { Command } from "../index.js";
+
+const ALLOWED_OPERATIONS: AccessKeyPermissionName[] = ["TokenTransfer"];
+
+export const accessKeyCreate: Command<AccessKeyCreateArgs> = {
+  cmd: "access-key-create",
+  handler: (args: AccessKeyCreateArgs) =>
+    Effect.gen(function* () {
+      const accounts = yield* AccountStore;
+      const accessKeyStore = yield* AccessKeyStore;
+      const config = yield* ClientConfig;
+      const keyManager = yield* KeyManagerApi;
+      const networkService = yield* NetworkConfigService;
+      const output = yield* Output;
+      const prompt = yield* Prompt;
+      const rpc = yield* FastRpc;
+
+      const ownerAccount = yield* accounts.resolveAccount(config.account);
+      const network = yield* networkService.resolve(config.network);
+      const tokenName = args.token ?? "USDC";
+      const token = resolveToken(tokenName, network);
+      const clientId = args.clientId?.trim() || DEFAULT_ACCESS_KEY_CLIENT_ID;
+      const label = args.label?.trim() || DEFAULT_ACCESS_KEY_LABEL;
+      const maxTotalSpend = decimalToBaseUnits(args.maxTotalSpendUsdc, token.decimals);
+      const expiresAt = new Date(
+        Date.now() + Math.max(1, args.expiresInHours) * 60 * 60 * 1000,
+      ).toISOString();
+      const expiresAtNanos = BigInt(Date.parse(expiresAt)) * 1_000_000n;
+      const allowedTokens = [toHex(token.fastTokenId)];
+
+      const password = ownerAccount.encrypted
+        ? yield* prompt.password()
+        : null;
+      const { seed } = yield* accounts.export(ownerAccount.name, password);
+      const signer = new Signer(seed);
+
+      const accountInfo = yield* rpc.getAccountInfo({
+        address: fromFastAddress(ownerAccount.fastAddress),
+        tokenBalancesFilter: null,
+        stateKeyFilter: null,
+        certificateByNonce: null,
+      } as never);
+      const nonce = (accountInfo as { nextNonce?: bigint }).nextNonce ?? 0n;
+
+      const delegatedSeed = crypto.getRandomValues(new Uint8Array(32));
+      const delegatedSigner = new Signer(delegatedSeed);
+      const delegatePublicKey = toHex(
+        yield* Effect.tryPromise({
+          try: () => delegatedSigner.getPublicKey(),
+          catch: (cause) =>
+            new TransactionFailedError({
+              message: "Failed to derive delegated public key",
+              cause,
+            }),
+        }),
+      );
+
+      if (!config.nonInteractive && !config.json) {
+        yield* output.humanLine(`Create access key for ${ownerAccount.name}`);
+        yield* output.humanLine(`  Owner:       ${ownerAccount.fastAddress}`);
+        yield* output.humanLine(`  Label:       ${label}`);
+        yield* output.humanLine(`  Client ID:   ${clientId}`);
+        yield* output.humanLine(`  Token:       ${tokenName}`);
+        yield* output.humanLine(`  Spend cap:   ${args.maxTotalSpendUsdc} ${tokenName}`);
+        yield* output.humanLine(`  Expires at:  ${expiresAt}`);
+        yield* output.humanLine(`  Key manager: ${keyManager.baseUrl}`);
+        yield* output.humanLine("");
+        const confirmed = yield* prompt.confirm("Create access key?");
+        if (!confirmed) {
+          return;
+        }
+      }
+
+      const prepared = yield* Effect.tryPromise({
+        try: () =>
+          buildAuthorizeAccessKeyEnvelope({
+            signer,
+            ownerFastAddress: ownerAccount.fastAddress,
+            networkId: network.networkId,
+            nonce,
+            timestampNanos: nowNanos(),
+            delegatePublicKeyHex: delegatePublicKey,
+            clientId,
+            expiresAtNanos,
+            allowedOperations: ALLOWED_OPERATIONS,
+            allowedTokenIds: allowedTokens,
+            maxTotalSpend,
+          }),
+        catch: (cause) =>
+          new TransactionFailedError({
+            message: "Failed to build access-key authorization transaction",
+            cause,
+          }),
+      });
+
+      const submission = yield* Effect.tryPromise({
+        try: () => submitRawTransaction(network.rpcUrl, prepared.envelope),
+        catch: (cause) =>
+          cause instanceof TransactionFailedError
+            ? cause
+            : new TransactionFailedError({
+                message: "Failed to submit access-key authorization transaction",
+                cause,
+              }),
+      });
+
+      const certificate = extractSuccessCertificate(submission);
+      const storageResult = yield* Effect.either(
+        accessKeyStore.put({
+          accessKeyId: prepared.accessKeyId,
+          ownerAccountName: ownerAccount.name,
+          ownerFastAddress: ownerAccount.fastAddress,
+          network: config.network,
+          delegatePublicKey,
+          privateKey: delegatedSeed,
+          password,
+          label,
+          clientId,
+          createdAt: new Date().toISOString(),
+        }),
+      );
+      const registrationResult = yield* Effect.either(
+        keyManager.registerAccessKey({
+          ownerAccountAddress: ownerAccount.fastAddress,
+          accessKeyId: prepared.accessKeyId,
+          delegatePublicKey,
+          label,
+          source: "cli",
+          txHash: prepared.txHash,
+          certificate,
+          policy: {
+            clientId,
+            expiresAt,
+            allowedOperations: [...ALLOWED_OPERATIONS],
+            allowedTokens,
+            maxTotalSpend,
+          },
+        }),
+      );
+      const storedLocally = storageResult._tag === "Right";
+      const registeredToKeyManager = registrationResult._tag === "Right";
+      const registrationPolicy =
+        registrationResult._tag === "Right"
+          ? registrationResult.right.policy
+          : {
+              clientId,
+              expiresAt,
+              allowedOperations: [...ALLOWED_OPERATIONS],
+              allowedTokens,
+              maxTotalSpend,
+            };
+
+      const explorerUrl = `${network.explorerUrl}/txs/${prepared.txHash}`;
+      yield* output.humanLine(`Created access key "${label}"`);
+      yield* output.humanLine(`  Access key:  ${prepared.accessKeyId}`);
+      yield* output.humanLine(`  Transaction: ${prepared.txHash}`);
+      yield* output.humanLine(`  Explorer:    ${explorerUrl}`);
+      yield* output.humanLine(`  Client ID:   ${registrationPolicy.clientId}`);
+      if (!storedLocally) {
+        yield* output.humanLine(
+          `  Warning: local signer storage failed: ${storageResult.left.message}`,
+        );
+      }
+      if (!registeredToKeyManager) {
+        yield* output.humanLine(
+          `  Warning: key-manager registration failed: ${registrationResult.left.message}`,
+        );
+      }
+      yield* output.ok({
+        accessKeyId: prepared.accessKeyId,
+        txHash: prepared.txHash,
+        explorerUrl,
+        ownerAccount: ownerAccount.fastAddress,
+        delegatePublicKey,
+        label,
+        clientId,
+        expiresAt,
+        allowedOperations: ALLOWED_OPERATIONS,
+        allowedTokens,
+        maxTotalSpend,
+        source: "cli",
+        storedLocally,
+        registeredToKeyManager,
+        storageError: storedLocally ? null : storageResult.left.message,
+        keyManagerError: registeredToKeyManager ? null : registrationResult.left.message,
+      });
+    }),
+};

--- a/app/cli/src/commands/access-key/list.ts
+++ b/app/cli/src/commands/access-key/list.ts
@@ -1,0 +1,139 @@
+import { Effect } from "effect";
+import type { AccessKeyListArgs } from "../../cli.js";
+import { Output } from "../../services/output.js";
+import { AccessKeyStore } from "../../services/storage/access-key.js";
+import { AccountStore } from "../../services/storage/account.js";
+import { ClientConfig } from "../../services/config/client.js";
+import { KeyManagerApi } from "../../services/api/key-manager.js";
+import { NetworkConfigService } from "../../services/storage/network.js";
+import {
+  formatBaseUnits,
+  statusForAccessKey,
+} from "../../services/access-key-runtime.js";
+import type { Command } from "../index.js";
+
+function resolveTokenName(
+  tokenId: string | undefined,
+  network: {
+    readonly allSet?: {
+      readonly chains: Record<
+        string,
+        {
+          readonly tokens: Record<string, { readonly fastTokenId: string }>;
+        }
+      >;
+    };
+  },
+): string {
+  if (!tokenId || !network.allSet) {
+    return tokenId ?? "-";
+  }
+  for (const chain of Object.values(network.allSet.chains)) {
+    for (const [name, token] of Object.entries(chain.tokens)) {
+      if (token.fastTokenId.toLowerCase() === tokenId.toLowerCase()) {
+        return name;
+      }
+    }
+  }
+  return tokenId;
+}
+
+export const accessKeyList: Command<AccessKeyListArgs> = {
+  cmd: "access-key-list",
+  handler: (_args: AccessKeyListArgs) =>
+    Effect.gen(function* () {
+      const accounts = yield* AccountStore;
+      const accessKeyStore = yield* AccessKeyStore;
+      const config = yield* ClientConfig;
+      const keyManager = yield* KeyManagerApi;
+      const networkService = yield* NetworkConfigService;
+      const output = yield* Output;
+
+      const ownerAccount = yield* accounts.resolveAccount(config.account);
+      const network = yield* networkService.resolve(config.network);
+      const [remoteKeys, localKeys] = yield* Effect.all([
+        keyManager.listAccessKeys(ownerAccount.fastAddress),
+        accessKeyStore.list(ownerAccount.fastAddress, config.network),
+      ]);
+
+      const rowsById = new Map<string, {
+        accessKeyId: string;
+        label: string;
+        source: string;
+        clientId: string;
+        token: string;
+        remaining: string | null;
+        status: string;
+        local: boolean;
+        createdAt: string | null;
+      }>();
+
+      for (const key of remoteKeys) {
+        const tokenId = key.policy.allowedTokens[0];
+        const tokenName = resolveTokenName(tokenId, network);
+        const decimals = tokenName.toUpperCase().includes("USDC") ? 6 : 0;
+        rowsById.set(key.accessKeyId, {
+          accessKeyId: key.accessKeyId,
+          label: key.label ?? key.accessKeyId,
+          source: key.source ?? "external",
+          clientId: key.policy.clientId,
+          token: tokenName,
+          remaining: formatBaseUnits(key.capabilities.remainingTotalSpend, decimals),
+          status: statusForAccessKey(key),
+          local: false,
+          createdAt: key.createdAt ? String(key.createdAt) : null,
+        });
+      }
+
+      for (const key of localKeys) {
+        const existing = rowsById.get(key.accessKeyId);
+        if (existing) {
+          rowsById.set(key.accessKeyId, {
+            ...existing,
+            label: existing.label === key.accessKeyId && key.label ? key.label : existing.label,
+            clientId: existing.clientId || key.clientId,
+            createdAt: existing.createdAt ?? key.createdAt,
+            local: true,
+          });
+          continue;
+        }
+
+        rowsById.set(key.accessKeyId, {
+          accessKeyId: key.accessKeyId,
+          label: key.label ?? key.accessKeyId,
+          source: "local-only",
+          clientId: key.clientId,
+          token: "-",
+          remaining: null,
+          status: "unregistered",
+          local: true,
+          createdAt: key.createdAt ?? null,
+        });
+      }
+
+      const rows = [...rowsById.values()].sort((left, right) =>
+        (right.createdAt ?? "").localeCompare(left.createdAt ?? ""),
+      );
+
+      if (rows.length === 0) {
+        yield* output.humanLine(`No access keys found for ${ownerAccount.fastAddress}`);
+      } else {
+        yield* output.humanTable(
+          ["LABEL", "STATUS", "SOURCE", "CLIENT", "TOKEN", "LOCAL"],
+          rows.map((row) => [
+            row.label,
+            row.status,
+            row.source,
+            row.clientId,
+            row.token,
+            row.local ? "yes" : "no",
+          ]),
+        );
+      }
+
+      yield* output.ok({
+        ownerAccount: ownerAccount.fastAddress,
+        accessKeys: rows,
+      });
+    }),
+};

--- a/app/cli/src/commands/access-key/revoke.ts
+++ b/app/cli/src/commands/access-key/revoke.ts
@@ -1,0 +1,138 @@
+import { fromFastAddress, Signer } from "@fastxyz/sdk";
+import { Effect } from "effect";
+import type { AccessKeyRevokeArgs } from "../../cli.js";
+import { InvalidUsageError, TransactionFailedError } from "../../errors/index.js";
+import { buildRevokeAccessKeyEnvelope } from "../../services/access-key-protocol.js";
+import {
+  submitRawTransaction,
+  extractSuccessCertificate,
+  nowNanos,
+} from "../../services/access-key-runtime.js";
+import { KeyManagerApi } from "../../services/api/key-manager.js";
+import { Output } from "../../services/output.js";
+import { Prompt } from "../../services/prompt.js";
+import { AccessKeyStore } from "../../services/storage/access-key.js";
+import { AccountStore } from "../../services/storage/account.js";
+import { NetworkConfigService } from "../../services/storage/network.js";
+import { FastRpc } from "../../services/api/fast.js";
+import { ClientConfig } from "../../services/config/client.js";
+import type { Command } from "../index.js";
+
+const isHex32 = (value: string) => /^(0x)?[0-9a-fA-F]{64}$/.test(value);
+
+export const accessKeyRevoke: Command<AccessKeyRevokeArgs> = {
+  cmd: "access-key-revoke",
+  handler: (args: AccessKeyRevokeArgs) =>
+    Effect.gen(function* () {
+      if (!isHex32(args.accessKeyId)) {
+        return yield* Effect.fail(
+          new InvalidUsageError({
+            message: `Invalid access key ID "${args.accessKeyId}". Expected a 32-byte hex string.`,
+          }),
+        );
+      }
+
+      const accounts = yield* AccountStore;
+      const accessKeyStore = yield* AccessKeyStore;
+      const config = yield* ClientConfig;
+      const keyManager = yield* KeyManagerApi;
+      const networkService = yield* NetworkConfigService;
+      const output = yield* Output;
+      const prompt = yield* Prompt;
+      const rpc = yield* FastRpc;
+
+      const ownerAccount = yield* accounts.resolveAccount(config.account);
+      const network = yield* networkService.resolve(config.network);
+
+      if (!config.nonInteractive && !config.json) {
+        yield* output.humanLine(`Revoke access key ${args.accessKeyId}`);
+        yield* output.humanLine(`  Owner: ${ownerAccount.fastAddress}`);
+        yield* output.humanLine("");
+        const confirmed = yield* prompt.confirm("Revoke access key?");
+        if (!confirmed) {
+          return;
+        }
+      }
+
+      const password = ownerAccount.encrypted
+        ? yield* prompt.password()
+        : null;
+      const { seed } = yield* accounts.export(ownerAccount.name, password);
+      const signer = new Signer(seed);
+
+      const accountInfo = yield* rpc.getAccountInfo({
+        address: fromFastAddress(ownerAccount.fastAddress),
+        tokenBalancesFilter: null,
+        stateKeyFilter: null,
+        certificateByNonce: null,
+      } as never);
+      const nonce = (accountInfo as { nextNonce?: bigint }).nextNonce ?? 0n;
+
+      const prepared = yield* Effect.tryPromise({
+        try: () =>
+          buildRevokeAccessKeyEnvelope({
+            signer,
+            ownerFastAddress: ownerAccount.fastAddress,
+            networkId: network.networkId,
+            nonce,
+            timestampNanos: nowNanos(),
+            accessKeyId: args.accessKeyId,
+          }),
+        catch: (cause) =>
+          new TransactionFailedError({
+            message: "Failed to build access-key revocation transaction",
+            cause,
+          }),
+      });
+
+      const submission = yield* Effect.tryPromise({
+        try: () => submitRawTransaction(network.rpcUrl, prepared.envelope),
+        catch: (cause) =>
+          cause instanceof TransactionFailedError
+            ? cause
+            : new TransactionFailedError({
+                message: "Failed to submit access-key revocation transaction",
+                cause,
+              }),
+      });
+
+      const certificate = extractSuccessCertificate(submission);
+      const registrationResult = yield* Effect.either(
+        keyManager.registerAccessKeyRevocation({
+          ownerAccountAddress: ownerAccount.fastAddress,
+          accessKeyId: args.accessKeyId,
+          txHash: prepared.txHash,
+          certificate,
+        }),
+      );
+      const removalResult = yield* Effect.either(
+        accessKeyStore.remove(args.accessKeyId),
+      );
+      const registeredToKeyManager = registrationResult._tag === "Right";
+      const removedLocally = removalResult._tag === "Right";
+
+      const explorerUrl = `${network.explorerUrl}/txs/${prepared.txHash}`;
+      yield* output.humanLine(`Revoked access key ${args.accessKeyId}`);
+      yield* output.humanLine(`  Transaction: ${prepared.txHash}`);
+      yield* output.humanLine(`  Explorer:    ${explorerUrl}`);
+      if (!registeredToKeyManager) {
+        yield* output.humanLine(
+          `  Warning: key-manager revocation sync failed: ${registrationResult.left.message}`,
+        );
+      }
+      if (!removedLocally) {
+        yield* output.humanLine(
+          `  Warning: local key cleanup failed: ${removalResult.left.message}`,
+        );
+      }
+      yield* output.ok({
+        accessKeyId: args.accessKeyId,
+        txHash: prepared.txHash,
+        explorerUrl,
+        registeredToKeyManager,
+        removedLocally,
+        keyManagerError: registeredToKeyManager ? null : registrationResult.left.message,
+        localRemovalError: removedLocally ? null : removalResult.left.message,
+      });
+    }),
+};

--- a/app/cli/src/commands/index.ts
+++ b/app/cli/src/commands/index.ts
@@ -1,6 +1,9 @@
 import type { Effect } from "effect";
 import type { CommandName } from "../cli.js";
 import type { ClientError } from "../errors/index.js";
+import { accessKeyCreate } from "./access-key/create.js";
+import { accessKeyList } from "./access-key/list.js";
+import { accessKeyRevoke } from "./access-key/revoke.js";
 import { accountCreate } from "./account/create.js";
 import { accountDelete } from "./account/delete.js";
 import { accountExport } from "./account/export.js";
@@ -23,6 +26,9 @@ import { pay } from "./pay.js";
 import { send } from "./send.js";
 
 export const commands = [
+  accessKeyCreate,
+  accessKeyList,
+  accessKeyRevoke,
   accountCreate,
   accountDelete,
   accountExport,

--- a/app/cli/src/db/schema.ts
+++ b/app/cli/src/db/schema.ts
@@ -50,3 +50,22 @@ export const metadata = sqliteTable("metadata", {
   key: text("key").primaryKey(),
   value: text("value").notNull(),
 });
+
+export const accessKeys = sqliteTable(
+  "access_keys",
+  {
+    accessKeyId: text("access_key_id").primaryKey(),
+    ownerAccountName: text("owner_account_name").notNull(),
+    ownerFastAddress: text("owner_fast_address").notNull(),
+    network: text("network").notNull(),
+    delegatePublicKey: text("delegate_public_key").notNull(),
+    encryptedPrivateKey: blob("encrypted_private_key", { mode: "buffer" }).notNull(),
+    encrypted: integer("encrypted", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    label: text("label"),
+    clientId: text("client_id").notNull(),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [index("idx_access_keys_owner_network").on(table.ownerFastAddress, table.network)],
+);

--- a/app/cli/src/main.ts
+++ b/app/cli/src/main.ts
@@ -148,9 +148,10 @@ if (argv.length === 0 || argv.includes("--help")) {
 
 // ── Full parse ──────────────────────────────────────────────────────────────
 
-const KNOWN_COMMANDS = ["account", "network", "info", "send", "fund", "pay"] as const;
+const KNOWN_COMMANDS = ["access-key", "account", "network", "info", "send", "fund", "pay"] as const;
 
 const SUBCOMMANDS: Record<string, readonly string[]> = {
+  "access-key": ["create", "list", "revoke"],
   account: ["create", "import", "list", "set-default", "export", "delete"],
   network: ["list", "add", "set-default", "remove"],
   info: ["status", "balance", "tx", "history", "bridge-tokens", "bridge-chains"],
@@ -220,6 +221,24 @@ const SUBCOMMAND_REQUIREMENTS: Record<
     },
   },
   // ── Subcommands with required args/options ─────────────────────────────────
+  "access-key create": {
+    usage: "fast access-key create [--label <label>] [--client-id <client-id>] [--token <token>] [--expires-in-hours <hours>] [--max-total-spend-usdc <amount>]",
+    options: ["--label", "--client-id", "--token", "--expires-in-hours", "--max-total-spend-usdc"],
+    check: () => null,
+  },
+  "access-key list": {
+    usage: "fast access-key list",
+    options: [],
+    check: () => null,
+  },
+  "access-key revoke": {
+    usage: "fast access-key revoke <access-key-id>",
+    options: [],
+    check: (positionals) => {
+      if (positionals.length < 3) return "Missing required argument: <access-key-id>";
+      return null;
+    },
+  },
   "fund crypto": {
     usage: "fast fund crypto <amount> --chain <chain> [--token <token>]",
     options: ["--chain", "--token", "--eip-7702"],

--- a/app/cli/src/services/access-key-protocol.ts
+++ b/app/cli/src/services/access-key-protocol.ts
@@ -1,0 +1,293 @@
+import { bcs } from "@mysten/bcs";
+import { fromFastAddress, fromHex, hashHex, Signer, toHex } from "@fastxyz/sdk";
+import { keccak_256 } from "@noble/hashes/sha3.js";
+
+export const ACCESS_KEY_PERMISSION_NAMES = [
+  "TokenTransfer",
+  "TokenCreation",
+  "TokenManagement",
+  "Mint",
+  "Burn",
+  "StateInitialization",
+  "StateUpdate",
+  "StateReset",
+  "ExternalClaim",
+  "JoinCommittee",
+  "LeaveCommittee",
+  "ChangeCommittee",
+  "Escrow",
+  "AccessKeyManagement",
+] as const;
+
+export type AccessKeyPermissionName = (typeof ACCESS_KEY_PERMISSION_NAMES)[number];
+
+const AmountBcs = bcs.u256().transform({
+  input: (val: string) => BigInt(`0x${val.replace(/^0x/i, "")}`).toString(),
+});
+
+const AccessKeyPermissionBcs = bcs.enum("AccessKeyPermission", {
+  TokenTransfer: bcs.tuple([]),
+  TokenCreation: bcs.tuple([]),
+  TokenManagement: bcs.tuple([]),
+  Mint: bcs.tuple([]),
+  Burn: bcs.tuple([]),
+  StateInitialization: bcs.tuple([]),
+  StateUpdate: bcs.tuple([]),
+  StateReset: bcs.tuple([]),
+  ExternalClaim: bcs.tuple([]),
+  JoinCommittee: bcs.tuple([]),
+  LeaveCommittee: bcs.tuple([]),
+  ChangeCommittee: bcs.tuple([]),
+  Escrow: bcs.tuple([]),
+  AccessKeyManagement: bcs.tuple([]),
+});
+
+const AuthorizeAccessKeyBcs = bcs.struct("AuthorizeAccessKey", {
+  delegate: bcs.bytes(32),
+  client_id: bcs.string(),
+  expires_at: bcs.u128(),
+  allowed_operations: bcs.vector(AccessKeyPermissionBcs),
+  allowed_tokens: bcs.vector(bcs.bytes(32)),
+  max_total_spend: AmountBcs,
+});
+
+const RevokeAccessKeyBcs = bcs.struct("RevokeAccessKey", {
+  access_key_id: bcs.bytes(32),
+});
+
+const AccessKeyOperationBcs = bcs.enum("AccessKeyOperation", {
+  Authorize: AuthorizeAccessKeyBcs,
+  Revoke: RevokeAccessKeyBcs,
+});
+
+const TokenTransferBcs = bcs.struct("TokenTransfer", {
+  token_id: bcs.bytes(32),
+  recipient: bcs.bytes(32),
+  amount: AmountBcs,
+  user_data: bcs.option(bcs.bytes(32)),
+});
+
+const Release20260407OperationBcs = bcs.enum("OperationRelease20260407", {
+  TokenTransfer: TokenTransferBcs,
+  TokenCreation: bcs.tuple([]),
+  TokenManagement: bcs.tuple([]),
+  Mint: bcs.tuple([]),
+  Burn: bcs.tuple([]),
+  StateInitialization: bcs.tuple([]),
+  StateUpdate: bcs.tuple([]),
+  ExternalClaim: bcs.tuple([]),
+  StateReset: bcs.tuple([]),
+  JoinCommittee: bcs.tuple([]),
+  LeaveCommittee: bcs.tuple([]),
+  ChangeCommittee: bcs.tuple([]),
+  Escrow: bcs.tuple([]),
+  AccessKey: AccessKeyOperationBcs,
+});
+
+const Release20260319ClaimBcs = bcs.enum("ClaimType", {
+  TokenTransfer: TokenTransferBcs,
+});
+
+const Release20260319TransactionBcs = bcs.struct("TransactionRelease20260319", {
+  network_id: bcs.string(),
+  sender: bcs.bytes(32),
+  nonce: bcs.u64(),
+  timestamp_nanos: bcs.u128(),
+  claim: Release20260319ClaimBcs,
+  archival: bcs.bool(),
+  fee_token: bcs.option(bcs.bytes(32)),
+});
+
+const Release20260407TransactionBcs = bcs.struct("TransactionRelease20260407", {
+  network_id: bcs.string(),
+  sender: bcs.bytes(32),
+  nonce: bcs.u64(),
+  timestamp_nanos: bcs.u128(),
+  claims: bcs.vector(Release20260407OperationBcs),
+  archival: bcs.bool(),
+  fee_token: bcs.option(bcs.bytes(32)),
+});
+
+export const VersionedTransactionBcs = bcs.enum("VersionedTransaction", {
+  Release20260319: Release20260319TransactionBcs,
+  Release20260407: Release20260407TransactionBcs,
+});
+
+export interface Release20260407TransactionWire {
+  readonly Release20260407: {
+    readonly network_id: string;
+    readonly sender: number[];
+    readonly nonce: bigint;
+    readonly timestamp_nanos: bigint;
+    readonly claims: unknown[];
+    readonly archival: boolean;
+    readonly fee_token: null;
+  };
+}
+
+export interface RawTransactionEnvelope {
+  readonly transaction: Release20260407TransactionWire;
+  readonly signature: {
+    readonly Signature: number[];
+  };
+}
+
+const permissionVariant = (permission: AccessKeyPermissionName) => ({
+  [permission]: [] as const,
+});
+
+const amountToHex = (value: string | bigint): string => {
+  if (typeof value === "bigint") {
+    return value.toString(16);
+  }
+  const normalized = value.trim();
+  if (normalized.startsWith("0x") || normalized.startsWith("0X")) {
+    return normalized.slice(2);
+  }
+  return BigInt(normalized).toString(16);
+};
+
+const le64 = (value: bigint): Uint8Array => {
+  const bytes = new Uint8Array(8);
+  let remaining = value;
+  for (let index = 0; index < 8; index += 1) {
+    bytes[index] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  return bytes;
+};
+
+const concatBytes = (...parts: Uint8Array[]): Uint8Array => {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+};
+
+export const computeAccessKeyId = (
+  ownerFastAddress: string,
+  nonce: bigint,
+  operationIndex: number,
+): string => {
+  const bytes = concatBytes(
+    fromFastAddress(ownerFastAddress),
+    le64(nonce),
+    le64(BigInt(operationIndex)),
+  );
+  return toHex(keccak_256(bytes));
+};
+
+export interface BuildAuthorizeAccessKeyEnvelopeInput {
+  readonly signer: Signer;
+  readonly ownerFastAddress: string;
+  readonly networkId: string;
+  readonly nonce: bigint;
+  readonly timestampNanos: bigint;
+  readonly delegatePublicKeyHex: string;
+  readonly clientId: string;
+  readonly expiresAtNanos: bigint;
+  readonly allowedOperations: AccessKeyPermissionName[];
+  readonly allowedTokenIds: string[];
+  readonly maxTotalSpend: string;
+}
+
+export interface BuildRevokeAccessKeyEnvelopeInput {
+  readonly signer: Signer;
+  readonly ownerFastAddress: string;
+  readonly networkId: string;
+  readonly nonce: bigint;
+  readonly timestampNanos: bigint;
+  readonly accessKeyId: string;
+}
+
+async function signEnvelope(
+  signer: Signer,
+  transaction: Release20260407TransactionWire,
+): Promise<RawTransactionEnvelope> {
+  const signature = await signer.signTypedData(VersionedTransactionBcs, transaction);
+  return {
+    transaction,
+    signature: {
+      Signature: Array.from(signature),
+    },
+  };
+}
+
+export async function buildAuthorizeAccessKeyEnvelope(
+  input: BuildAuthorizeAccessKeyEnvelopeInput,
+): Promise<{
+  readonly accessKeyId: string;
+  readonly txHash: string;
+  readonly transaction: Release20260407TransactionWire;
+  readonly envelope: RawTransactionEnvelope;
+}> {
+  const transaction: Release20260407TransactionWire = {
+    Release20260407: {
+      network_id: input.networkId,
+      sender: Array.from(fromFastAddress(input.ownerFastAddress)),
+      nonce: input.nonce,
+      timestamp_nanos: input.timestampNanos,
+      claims: [
+        {
+          AccessKey: {
+            Authorize: {
+              delegate: Array.from(fromHex(input.delegatePublicKeyHex)),
+              client_id: input.clientId,
+              expires_at: input.expiresAtNanos,
+              allowed_operations: input.allowedOperations.map(permissionVariant),
+              allowed_tokens: input.allowedTokenIds.map((tokenId) => Array.from(fromHex(tokenId))),
+              max_total_spend: amountToHex(input.maxTotalSpend),
+            },
+          },
+        },
+      ],
+      archival: false,
+      fee_token: null,
+    },
+  };
+
+  const txHash = await hashHex(VersionedTransactionBcs, transaction);
+  const accessKeyId = computeAccessKeyId(
+    input.ownerFastAddress,
+    input.nonce,
+    0,
+  );
+  const envelope = await signEnvelope(input.signer, transaction);
+  return { accessKeyId, txHash, transaction, envelope };
+}
+
+export async function buildRevokeAccessKeyEnvelope(
+  input: BuildRevokeAccessKeyEnvelopeInput,
+): Promise<{
+  readonly txHash: string;
+  readonly transaction: Release20260407TransactionWire;
+  readonly envelope: RawTransactionEnvelope;
+}> {
+  const transaction: Release20260407TransactionWire = {
+    Release20260407: {
+      network_id: input.networkId,
+      sender: Array.from(fromFastAddress(input.ownerFastAddress)),
+      nonce: input.nonce,
+      timestamp_nanos: input.timestampNanos,
+      claims: [
+        {
+          AccessKey: {
+            Revoke: {
+              access_key_id: Array.from(fromHex(input.accessKeyId)),
+            },
+          },
+        },
+      ],
+      archival: false,
+      fee_token: null,
+    },
+  };
+
+  const txHash = await hashHex(VersionedTransactionBcs, transaction);
+  const envelope = await signEnvelope(input.signer, transaction);
+  return { txHash, transaction, envelope };
+}

--- a/app/cli/src/services/access-key-runtime.ts
+++ b/app/cli/src/services/access-key-runtime.ts
@@ -1,0 +1,108 @@
+import { JSONParse, JSONStringify } from "json-with-bigint";
+import { TransactionFailedError } from "../errors/index.js";
+import type { RawTransactionEnvelope } from "./access-key-protocol.js";
+
+export const DEFAULT_ACCESS_KEY_CLIENT_ID = "app.fast.xyz";
+export const DEFAULT_ACCESS_KEY_EXPIRY_HOURS = 24 * 30;
+export const DEFAULT_ACCESS_KEY_LABEL = "FAST CLI access key";
+export const DEFAULT_ACCESS_KEY_MAX_TOTAL_SPEND_USDC = "250.00";
+export const DEFAULT_ACCESS_KEY_TOKEN = "USDC";
+
+export const nowNanos = (): bigint => BigInt(Date.now()) * 1_000_000n;
+
+export const decimalToBaseUnits = (value: string, decimals: number): string => {
+  const normalized = value.trim();
+  if (!/^\d+(\.\d+)?$/.test(normalized)) {
+    throw new TransactionFailedError({
+      message: `Invalid amount "${value}". Expected a positive decimal number.`,
+    });
+  }
+
+  const [whole, fraction = ""] = normalized.split(".");
+  if (fraction.length > decimals) {
+    throw new TransactionFailedError({
+      message: `Amount "${value}" has too many decimal places (max ${decimals}).`,
+    });
+  }
+
+  const paddedFraction = fraction.padEnd(decimals, "0");
+  const raw = `${whole}${paddedFraction}`.replace(/^0+/, "") || "0";
+  if (BigInt(raw) <= 0n) {
+    throw new TransactionFailedError({
+      message: `Amount must be greater than zero (got "${value}").`,
+    });
+  }
+  return raw;
+};
+
+export const statusForAccessKey = (record: {
+  readonly capabilities: { readonly revoked: boolean };
+  readonly policy: { readonly expiresAt: string | number | bigint | null };
+}) => {
+  if (record.capabilities.revoked) {
+    return "revoked";
+  }
+  if (record.policy.expiresAt !== null) {
+    const expiresAtMs = new Date(String(record.policy.expiresAt)).getTime();
+    if (Number.isFinite(expiresAtMs) && expiresAtMs <= Date.now()) {
+      return "expired";
+    }
+  }
+  return "active";
+};
+
+export const formatBaseUnits = (value: string | number | bigint | null, decimals: number): string | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const raw = BigInt(value);
+  const whole = raw / 10n ** BigInt(decimals);
+  const fraction = raw % 10n ** BigInt(decimals);
+  if (fraction === 0n) {
+    return whole.toString();
+  }
+  return `${whole}.${fraction.toString().padStart(decimals, "0").replace(/0+$/, "")}`;
+};
+
+export const submitRawTransaction = async (
+  rpcUrl: string,
+  envelope: RawTransactionEnvelope,
+): Promise<Record<string, unknown>> => {
+  const body = JSONStringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "proxy_submitTransaction",
+    params: envelope,
+  });
+
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+
+  const text = await response.text();
+  const json = JSONParse(text) as {
+    result?: Record<string, unknown>;
+    error?: { message?: string };
+  };
+
+  if (!response.ok || json.error) {
+    throw new TransactionFailedError({
+      message: json.error?.message ?? `FAST RPC submit failed (${response.status})`,
+    });
+  }
+
+  return json.result ?? {};
+};
+
+export const extractSuccessCertificate = (
+  result: Record<string, unknown>,
+): Record<string, unknown> => {
+  if ("Success" in result && result.Success && typeof result.Success === "object") {
+    return result.Success as Record<string, unknown>;
+  }
+  throw new TransactionFailedError({
+    message: `FAST RPC did not return a finalized certificate: ${JSONStringify(result)}`,
+  });
+};

--- a/app/cli/src/services/api/key-manager.ts
+++ b/app/cli/src/services/api/key-manager.ts
@@ -1,0 +1,134 @@
+import { Context, Effect, Layer } from "effect";
+import { JSONParse, JSONStringify } from "json-with-bigint";
+import { FastSdkError } from "../../errors/index.js";
+
+export type AccessKeySource = "browser" | "cli" | "external";
+
+export interface KeyManagerAccessKeyRecord {
+  readonly accessKeyId: string;
+  readonly accountAddress: string;
+  readonly source?: AccessKeySource;
+  readonly delegatePublicKey?: string;
+  readonly label?: string;
+  readonly createdAt?: string | number | bigint | null;
+  readonly creation?: {
+    readonly txHash: string;
+    readonly certificate: Record<string, unknown>;
+    readonly confirmedAt: string;
+  };
+  readonly revocation?: {
+    readonly txHash: string;
+    readonly certificate: Record<string, unknown>;
+    readonly confirmedAt: string;
+  };
+  readonly policy: {
+    readonly clientId: string;
+    readonly expiresAt: string | number | bigint | null;
+    readonly allowedOperations: string[];
+    readonly allowedTokens: string[];
+    readonly maxTotalSpend: string | number | bigint | null;
+  };
+  readonly capabilities: {
+    readonly clientId: string;
+    readonly expiresAt: string | number | bigint | null;
+    readonly allowedOperations: string[];
+    readonly allowedTokens: string[];
+    readonly maxTotalSpend: string | number | bigint | null;
+    readonly remainingTotalSpend: string | number | bigint | null;
+    readonly revoked: boolean;
+  };
+}
+
+export interface RegisterAccessKeyRequest {
+  readonly ownerAccountAddress: string;
+  readonly accessKeyId: string;
+  readonly delegatePublicKey: string;
+  readonly label?: string;
+  readonly source: AccessKeySource;
+  readonly txHash: string;
+  readonly certificate: Record<string, unknown>;
+  readonly policy: {
+    readonly clientId: string;
+    readonly expiresAt: string;
+    readonly allowedOperations: string[];
+    readonly allowedTokens: string[];
+    readonly maxTotalSpend: string;
+  };
+}
+
+export interface RegisterAccessKeyRevocationRequest {
+  readonly ownerAccountAddress: string;
+  readonly accessKeyId: string;
+  readonly txHash: string;
+  readonly certificate: Record<string, unknown>;
+}
+
+export interface KeyManagerApiShape {
+  readonly baseUrl: string;
+  readonly listAccessKeys: (
+    ownerAccountAddress: string,
+  ) => Effect.Effect<KeyManagerAccessKeyRecord[], FastSdkError>;
+  readonly registerAccessKey: (
+    body: RegisterAccessKeyRequest,
+  ) => Effect.Effect<KeyManagerAccessKeyRecord, FastSdkError>;
+  readonly registerAccessKeyRevocation: (
+    body: RegisterAccessKeyRevocationRequest,
+  ) => Effect.Effect<KeyManagerAccessKeyRecord, FastSdkError>;
+}
+
+export class KeyManagerApi extends Context.Tag("KeyManagerApi")<
+  KeyManagerApi,
+  KeyManagerApiShape
+>() {}
+
+const DEFAULT_KEY_MANAGER_URL = process.env.FAST_KEY_MANAGER_URL ?? "https://keys.fast.xyz";
+
+const readJson = async <T>(response: Response): Promise<T> => {
+  const text = await response.text();
+  if (!text.trim()) {
+    return {} as T;
+  }
+  return JSONParse(text) as T;
+};
+
+const requestJson = <T>(
+  path: string,
+  init?: RequestInit,
+) =>
+  Effect.tryPromise({
+    try: async () => {
+      const response = await fetch(`${DEFAULT_KEY_MANAGER_URL}${path}`, init);
+      if (!response.ok) {
+        const body = await readJson<{ error?: string }>(response).catch(() => ({ error: response.statusText }));
+        throw new Error(body.error ?? `Key manager request failed (${response.status})`);
+      }
+      return readJson<T>(response);
+    },
+    catch: (cause) =>
+      cause instanceof FastSdkError
+        ? cause
+        : new FastSdkError({
+            message: cause instanceof Error ? cause.message : String(cause),
+            cause,
+          }),
+  });
+
+export const KeyManagerApiLive = Layer.succeed(KeyManagerApi, {
+  baseUrl: DEFAULT_KEY_MANAGER_URL,
+  listAccessKeys: (ownerAccountAddress: string) =>
+    requestJson<KeyManagerAccessKeyRecord[]>(
+      `/access-keys?ownerAccountAddress=${encodeURIComponent(ownerAccountAddress)}`,
+    ),
+  registerAccessKey: (body: RegisterAccessKeyRequest) =>
+    requestJson<KeyManagerAccessKeyRecord>("/access-keys/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSONStringify(body),
+    }),
+  registerAccessKeyRevocation: (body: RegisterAccessKeyRevocationRequest) =>
+    requestJson<KeyManagerAccessKeyRecord>("/access-keys/revoke/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSONStringify(body),
+    }),
+});

--- a/app/cli/src/services/storage/access-key.ts
+++ b/app/cli/src/services/storage/access-key.ts
@@ -1,0 +1,147 @@
+import { and, eq } from "drizzle-orm";
+import { Effect } from "effect";
+import { accessKeys } from "../../db/schema.js";
+import { DatabaseError } from "../../errors/index.js";
+import { storeSeed } from "../crypto.js";
+import {
+  DatabaseService,
+  type DatabaseShape,
+  type DrizzleDB,
+} from "./database.js";
+
+export interface StoredAccessKeyInfo {
+  readonly accessKeyId: string;
+  readonly ownerAccountName: string;
+  readonly ownerFastAddress: string;
+  readonly network: string;
+  readonly delegatePublicKey: string;
+  readonly encrypted: boolean;
+  readonly label: string | null;
+  readonly clientId: string;
+  readonly createdAt: string;
+}
+
+export interface StoreAccessKeyInput {
+  readonly accessKeyId: string;
+  readonly ownerAccountName: string;
+  readonly ownerFastAddress: string;
+  readonly network: string;
+  readonly delegatePublicKey: string;
+  readonly privateKey: Uint8Array;
+  readonly password: string | null;
+  readonly label: string | null;
+  readonly clientId: string;
+  readonly createdAt: string;
+}
+
+const rowToInfo = (row: typeof accessKeys.$inferSelect): StoredAccessKeyInfo => ({
+  accessKeyId: row.accessKeyId,
+  ownerAccountName: row.ownerAccountName,
+  ownerFastAddress: row.ownerFastAddress,
+  network: row.network,
+  delegatePublicKey: row.delegatePublicKey,
+  encrypted: row.encrypted,
+  label: row.label,
+  clientId: row.clientId,
+  createdAt: row.createdAt,
+});
+
+const listByOwner = (db: DrizzleDB, ownerFastAddress: string, network: string) =>
+  db
+    .select()
+    .from(accessKeys)
+    .where(
+      and(
+        eq(accessKeys.ownerFastAddress, ownerFastAddress),
+        eq(accessKeys.network, network),
+      ),
+    )
+    .orderBy(accessKeys.createdAt)
+    .all();
+
+const getById = (db: DrizzleDB, accessKeyId: string) =>
+  db.select().from(accessKeys).where(eq(accessKeys.accessKeyId, accessKeyId)).get();
+
+const put = (
+  handle: DatabaseShape,
+  input: StoreAccessKeyInput,
+) =>
+  Effect.gen(function* () {
+    const encryptedPrivateKey = yield* Effect.tryPromise({
+      try: () => storeSeed(input.privateKey, input.password),
+      catch: (cause) =>
+        new DatabaseError({ message: "Failed to encrypt access key material", cause }),
+    });
+
+    yield* handle.query(
+      (db) =>
+        db
+          .insert(accessKeys)
+          .values({
+            accessKeyId: input.accessKeyId,
+            ownerAccountName: input.ownerAccountName,
+            ownerFastAddress: input.ownerFastAddress,
+            network: input.network,
+            delegatePublicKey: input.delegatePublicKey,
+            encryptedPrivateKey: Buffer.from(encryptedPrivateKey),
+            encrypted: input.password !== null,
+            label: input.label,
+            clientId: input.clientId,
+            createdAt: input.createdAt,
+          })
+          .onConflictDoUpdate({
+            target: accessKeys.accessKeyId,
+            set: {
+              ownerAccountName: input.ownerAccountName,
+              ownerFastAddress: input.ownerFastAddress,
+              network: input.network,
+              delegatePublicKey: input.delegatePublicKey,
+              encryptedPrivateKey: Buffer.from(encryptedPrivateKey),
+              encrypted: input.password !== null,
+              label: input.label,
+              clientId: input.clientId,
+              createdAt: input.createdAt,
+            },
+          })
+          .run(),
+      "Failed to store access key material",
+    );
+  });
+
+const remove = (handle: DatabaseShape, accessKeyId: string) =>
+  handle.query(
+    (db) => db.delete(accessKeys).where(eq(accessKeys.accessKeyId, accessKeyId)).run(),
+    "Failed to remove access key material",
+  );
+
+const list = (handle: DatabaseShape, ownerFastAddress: string, network: string) =>
+  Effect.map(
+    handle.query(
+      (db) => listByOwner(db, ownerFastAddress, network),
+      "Failed to list access keys",
+    ),
+    (rows) => rows.map(rowToInfo),
+  );
+
+const has = (handle: DatabaseShape, accessKeyId: string) =>
+  Effect.map(
+    handle.query((db) => getById(db, accessKeyId), "Failed to load access key"),
+    (row) => row !== undefined,
+  );
+
+const ServiceEffect = Effect.gen(function* () {
+  const handle = yield* DatabaseService;
+
+  return {
+    put: (input: StoreAccessKeyInput) => put(handle, input),
+    remove: (accessKeyId: string) => remove(handle, accessKeyId),
+    list: (ownerFastAddress: string, network: string) =>
+      list(handle, ownerFastAddress, network),
+    has: (accessKeyId: string) => has(handle, accessKeyId),
+  };
+});
+
+export class AccessKeyStore extends Effect.Service<AccessKeyStore>()(
+  "AccessKeyStore",
+  { effect: ServiceEffect },
+) {}

--- a/app/cli/tsup.config.ts
+++ b/app/cli/tsup.config.ts
@@ -14,9 +14,11 @@ export default defineConfig({
     '@fastxyz/schema',
     '@fastxyz/sdk',
     '@fastxyz/x402-client',
+    '@mysten/bcs',
     '@noble/curves',
     '@noble/ciphers',
     '@noble/hashes',
+    'json-with-bigint',
   ],
   banner: {
     js: '#!/usr/bin/env node',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@effect/typeclass':
         specifier: ^0.40.0
         version: 0.40.0(effect@3.21.0)
+      '@mysten/bcs':
+        specifier: ^2.0.3
+        version: 2.0.3
       '@optique/core':
         specifier: ^0.10.7
         version: 0.10.7
@@ -74,6 +77,9 @@ importers:
       effect:
         specifier: ^3.21.0
         version: 3.21.0
+      json-with-bigint:
+        specifier: ^3.5.8
+        version: 3.5.8
       uuid:
         specifier: ^11.1.0
         version: 11.1.0


### PR DESCRIPTION
## Summary
- add `fast access-key create`, `list`, and `revoke`
- persist CLI-managed access-key signer material in the local CLI database
- register CLI-created access keys and revocations with the shared key-manager service
- surface partial-success cases after on-chain finalization instead of treating sync failures as full transaction failures
- include local-only keys in `access-key list` when registry sync has not landed remotely yet
- add the repo implementation plan document and CLI docs

## Why
The CLI needs to create the same access-key lifecycle objects that the web app can see. This wires the CLI into the shared key-manager contract while keeping delegated signer material local to the CLI runtime.

## User impact
- users can create, inspect, and revoke FAST access keys from the CLI
- successful on-chain create/revoke operations now report local storage and key-manager sync status explicitly
- CLI-created keys can be registered so they appear in `app.fast.xyz`

## Validation
- `pnpm --filter @fastxyz/cli build`
- `node app/cli/dist/main.js access-key --help`
