### PR TITLE
feat(cli): fund command restructure + fastUSD adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ fast info balance
 # Send tokens on Fast
 fast send fast1recipient... 1000 --token USDC
 
-# Fund via fiat on-ramp
-fast fund fiat --network mainnet
+# Fund via fiat on-ramp (USDC → fastUSDC)
+fast fund usdc fiat --network mainnet
 
 # Pay for x402-protected resource
 fast pay https://api.example.com/protected

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ fast info balance
 # Send tokens on Fast
 fast send fast1recipient... 1000 --token USDC
 
-# Fund via fiat on-ramp (USDC → fastUSDC)
+# Fund via fiat on-ramp (delivers USDC to your Fast account)
 fast fund usdc fiat --network mainnet
 
 # Pay for x402-protected resource
@@ -175,5 +175,3 @@ MIT
 ## Legal
 
 Use of the SDK constitutes acceptance of both [Terms of Service](https://pi2labs.org/terms-of-service) and [Acceptable Use Policy](https://pi2labs.org/acceptable-use-policy)
-
-

--- a/SPEC.md
+++ b/SPEC.md
@@ -20,7 +20,7 @@ tool for managing accounts, moving assets, and querying network state.
   human-readable output, and sensible defaults.
 - **Single entry point.** No sub-skills, no separate binaries. One CLI covers
   Fast-to-Fast transfers, EVM-Fast transfers, on-ramp funding, and payments via protocols such as x402.
-- **≤7 top-level command.** A thin surface is preferred by agents.
+- **≤7 top-level commands.** A thin surface is preferred by agents.
 
 ## 2. Global Flags
 
@@ -1029,7 +1029,7 @@ operations. Results are ordered by timestamp descending.
 
 ### 6.16 `fast info bridge-tokens`
 
-*Note: We only suppose USDC for now.*
+*Note: We only support USDC for now.*
 
 **Synopsis**
 
@@ -1133,7 +1133,7 @@ Fund a Fast account via fiat on-ramp or crypto bridge.
 **Synopsis**
 
 ```text
-fast fund usdc fiat [--address <fast-address>] [--token <value>] [--provider <provider>]
+fast fund usdc fiat [--address <fast-address>]
 ```
 
 **Description**
@@ -1146,14 +1146,17 @@ or bank transfer (on-ramp).
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `--address` | string | no | default account's Fast address | Fund to a specific Fast address. |
-| `--token` | string | no | `USDC` | Token to fund. See [Token Resolution](#7-token-resolution-rules). |
-| `--provider` | string | no | `swapper` | On-ramp provider. |
+
+The on-ramp provider and token are fixed (Ramp → USDC). If alternate
+providers or tokens become available, this section will gain `--provider`
+and `--token` flags.
 
 **Output (human)**
 
 ```text
-Fund USDC to fast1qw5...x9z via Swapper:
-  https://ramp.fast.xyz/?to=fast1...
+Open this URL in your browser to fund your account:
+
+  https://ramp.fast.xyz/?to=fast1qw5...x9z
 ```
 
 **Output (`--json`)**
@@ -1162,8 +1165,7 @@ Fund USDC to fast1qw5...x9z via Swapper:
 {
   "ok": true,
   "data": {
-    "url": "https://ramp.fast.xyz/...",
-    "provider": "swapper",
+    "url": "https://ramp.fast.xyz/?to=fast1qw5...x9z",
     "address": "fast1qw5...x9z",
     "tokenName": "USDC"
   }
@@ -1251,7 +1253,7 @@ with code 2 (`INVALID_AMOUNT`): `"Amount has too many decimal places for <token-
 |---|---|---|---|---|
 | `--from-chain` | string | no | — | Source chain for bridge-in. Must be a chain from `fast info bridge-chains`. |
 | `--to-chain` | string | no | — | Destination chain for bridge-out. Must be a chain from `fast info bridge-chains`. |
-| `--token` | string | no | `USDC` | Token to send. See [Token Resolution](#7-token-resolution-rules). Default is `USDC`. For Fast→Fast transfers, any token on the Fast network is supported (not limited to bridge tokens). For bridge operations, only tokens listed in `fast info bridge-tokens` are supported. |
+| `--token` | string | no | route-specific (see below) | Token to send. See [Token Resolution](#7-token-resolution-rules). Defaults depend on the route: Fast→Fast on mainnet uses `fastUSD`; Fast→Fast on testnet uses `testUSDC`; bridge routes use the chain's first configured token (typically `USDC` / `testUSDC`). For Fast→Fast transfers, any token on the Fast network is supported (not limited to bridge tokens). For bridge operations, only tokens listed in `fast info bridge-tokens` are supported. |
 | `--eip-7702` | boolean | no | `false` | Use EIP-7702 gasless deposit for EVM→Fast bridge-in. Only applies when `--from-chain` is set and recipient is `fast1...`. Gas is paid in token; no ETH required. |
 
 **Routing Rules**
@@ -1286,7 +1288,9 @@ deposit) are batched into a single UserOperation; gas is paid in token.
 
 **Behavior (interactive mode)**
 
-Before executing, display a confirmation summary:
+Before executing, display a confirmation summary. Example below assumes the
+caller passed `--token USDC`; if `--token` is omitted on mainnet Fast→Fast,
+the token line would read `fastUSD` instead (the route-specific default).
 
 ```text
 Send 10.50 USDC

--- a/SPEC.md
+++ b/SPEC.md
@@ -11,7 +11,7 @@ Date: 2026-03-31
 (`@fastxyz/sdk`) and the AllSet portal SDK (`@fastxyz/allset-sdk`) into a single
 tool for managing accounts, moving assets, and querying network state.
 
-### Design goals:
+### Design goals
 
 - **Agent-friendly.** Every command supports `--json` for structured output and
   `--help` for self-documenting usage. An AI agent's workflow is:
@@ -20,7 +20,7 @@ tool for managing accounts, moving assets, and querying network state.
   human-readable output, and sensible defaults.
 - **Single entry point.** No sub-skills, no separate binaries. One CLI covers
   Fast-to-Fast transfers, EVM-Fast transfers, on-ramp funding, and payments via protocols such as x402.
-- **≤7 top-level command.** A thin surface is preferred by agents. 
+- **≤7 top-level command.** A thin surface is preferred by agents.
 
 ## 2. Global Flags
 
@@ -908,7 +908,7 @@ fast info tx <hash> [--source <source>]
 **Description**
 
 Look up a single transaction by its hash. The `--source` flag specifies where
-to query; if missing, then it uses the default Fast network. 
+to query; if missing, then it uses the default Fast network.
 Returns the same transaction object shape as items in
 `fast info history`.
 
@@ -1029,7 +1029,7 @@ operations. Results are ordered by timestamp descending.
 
 ### 6.16 `fast info bridge-tokens`
 
-_Note: We only suppose USDC for now._
+*Note: We only suppose USDC for now.*
 
 **Synopsis**
 
@@ -1128,12 +1128,12 @@ Supported bridge chains on mainnet:
 
 Fund a Fast account via fiat on-ramp or crypto bridge.
 
-#### 6.18.1 `fast fund fiat`
+#### 6.18.1 `fast fund usdc fiat`
 
 **Synopsis**
 
 ```text
-fast fund [--address <fast-address>] [--token <value>] [--provider <provider>]
+fast fund usdc fiat [--address <fast-address>] [--token <value>] [--provider <provider>]
 ```
 
 **Description**
@@ -1178,19 +1178,20 @@ Fund USDC to fast1qw5...x9z via Swapper:
 | Invalid address format | 2 | `INVALID_ADDRESS` |
 | Unsupported provider | 2 | `UNSUPPORTED_PROVIDER` |
 
-#### 6.18.2 `fast fund crypto`
+#### 6.18.2 `fast fund usdc crypto`
 
 **Synopsis**
 
 ```text
-fast fund crypto <amount> --chain <chain> [--token <value>] [--eip-7702]
+fast fund usdc crypto <amount> --chain <chain> [--token <value>] [--eip-7702]
 ```
 
 **Description**
 
-Fund a Fast account by bridging tokens from an EVM chain. 
-The CLI checks the EVM balance of the account's derived EVM address 
+Fund a Fast account by bridging tokens from an EVM chain.
+The CLI checks the EVM balance of the account's derived EVM address
 (same underlying key) on the specified chain.
+
 - If the EVM balance is sufficient: bridge the requested amount to Fast automatically.
 - If the EVM balance is insufficient: print the EVM address and the shortfall
 amount, with a prompt indicating users to fund the provided EVM address,
@@ -1203,8 +1204,8 @@ address on the specified chain, then re-runs the same command.
 | ------ | ------ | -------- | --------------------------------------------- |
 | amount | string | yes      | Human-readable amount to fund (e.g., 100.00). |
 
-
 **Flags**
+
 | Flag         | Type    | Required | Default         | Description                                                                              |
 | ------------ | ------- | -------- | --------------- | ---------------------------------------------------------------------------------------- |
 | `--chain`    | string  | yes      | —               | EVM chain to bridge from. Values from `fast info bridge-chains`.                         |
@@ -1212,6 +1213,7 @@ address on the specified chain, then re-runs the same command.
 | `--eip-7702` | boolean | no       | false           | Use EIP-7702 gasless deposit (Account Abstraction). Gas is paid in token; no ETH needed. |
 
 **Behavior**
+
 1. Check the token balance on `--chain` for the (derived) EVM address.
 2. If balance >= amount: bridge tokens to Fast (standard EVM txs, or `smartDeposit()` with `--eip-7702`).
 3. If balance < amount: print the shortfall and the EVM address. Exit with
@@ -1273,7 +1275,6 @@ prompt; the CLI manages the underlying transactions.
 With `--eip-7702`, all three operations (approve paymaster, approve bridge,
 deposit) are batched into a single UserOperation; gas is paid in token.
 
-
 **Address validation rules:**
 
 - If no chain flags and address is `0x...`: exit code 2 —
@@ -1332,7 +1333,6 @@ operations, the command returns after the initiating transaction is confirmed
 on the source chain — it does **not** wait for the destination side to settle.
 Use `fast info tx <hash> --source <chain>` to check bridge completion status.
 
-
 **Errors**
 
 | Condition | Exit | Code |
@@ -1373,7 +1373,7 @@ needed).
 
 The CLI currently supports the x402 payment protocol. Payment type (Fast x402
 or chain x402) is selected automatically based on the server's accepted options
-and the account's available balances. Fast x402 is preferred when available. 
+and the account's available balances. Fast x402 is preferred when available.
 
 **Arguments**
 
@@ -1389,7 +1389,6 @@ and the account's available balances. Fast x402 is preferred when available.
 | `--method`  | string  | no       | `GET`     | HTTP method for the request.                                                                                                                                     |
 | `--header`  | string  | no       | —       | Custom header in key: value format. Repeatable for multiple headers.                                                                                             |
 | `--body`    | string  | no       | —       | Request body. Prefix with `@` to read from a file (e.g., `@request.json`).                                                                                           |
-
 
 The paying account is selected via the global `--account <name>` flag or the
 default account. Not required for `--dry-run`.
@@ -1434,6 +1433,7 @@ Pay from my-account? [Y/N]
 ```
 
 With auto-bridge:
+
 ```text
 Payment required:
   Merchant: api.example.com
@@ -1470,7 +1470,6 @@ The `response` field contains the HTTP status code and body returned by the
 merchant after successful payment. The `body` is the parsed JSON response, or
 a string if the response is not JSON. This is the content the agent is paying
 to access.
-
 
 **Output (`--json`, `--dry-run`)**
 
@@ -1597,4 +1596,4 @@ configuration. These are the canonical values accepted by `--from-chain`,
 requirements on chains not listed above (e.g., `base-sepolia`, `ethereum`).
 The CLI can fulfill chain x402 payments on any EVM chain where the account's
 derived EVM address has sufficient token balance. The tables above list only
-chains supported for bridging via `fast send` and `fast fund crypto`.
+chains supported for bridging via `fast send` and `fast fund usdc crypto`.

--- a/app/cli/README.md
+++ b/app/cli/README.md
@@ -35,8 +35,11 @@ fast info balance
 # Send USDC
 fast send fast1abc...xyz 10
 
-# Bridge from Arbitrum Sepolia to Fast
-fast fund crypto 50 --chain arbitrum-sepolia
+# Bridge from Arbitrum Sepolia to Fast (USDC → fastUSDC)
+fast fund usdc crypto 50 --chain arbitrum-sepolia
+
+# Or get a unified Fast web-app URL to fund fastUSD (mainnet only)
+fast fund fastusd --amount 50
 
 # Pay an x402-protected API
 fast pay https://api.example.com/resource
@@ -98,6 +101,7 @@ fast account import --name my-imported-account --private-key 0x...
 ```
 
 **Options:**
+
 - `--name <alias>` — Optional human-readable alias for the imported account
 - `--private-key <hex>` — Hex-encoded 32-byte private key
 - `--key-file <path>` — Path to a JSON file containing a `privateKey` field
@@ -157,10 +161,12 @@ fast send fast1recipient... 10.5 --token USDC
 ```
 
 **Positional arguments:**
+
 - `<address>` — Recipient address (`fast1...` for Fast, `0x...` for EVM)
 - `<amount>` — Human-readable amount (for example, `10` or `1.5`)
 
 **Options:**
+
 - `--from-chain <chain>` — Source EVM chain for EVM → Fast transfers
 - `--to-chain <chain>` — Destination EVM chain for Fast → EVM transfers
 - `--token <token>` — Token symbol or token ID (defaults to the first configured bridge token, typically `USDC`)
@@ -212,6 +218,7 @@ fast info history --from fast1... --limit 20
 ```
 
 **Options:**
+
 - `--from <address>` — Filter by sender address
 - `--to <address>` — Filter by recipient address
 - `--token <token>` — Filter by token name or token ID
@@ -240,39 +247,70 @@ fast info bridge-tokens
 
 ---
 
-### `fast fund fiat`
+### `fast fund usdc fiat`
 
-Get a fiat on-ramp URL for funding a Fast address.
+Get a fiat on-ramp URL for funding a Fast address with USDC. The URL targets
+[ramp.fast.xyz](https://ramp.fast.xyz). The deposit lands on Fast as
+**fastUSDC** (the EVM-bridged variant of USDC).
 
 ```bash
-fast fund fiat --network mainnet
+fast fund usdc fiat --network mainnet
 ```
 
 **Requirements:**
-- Only available on `mainnet`
-- Prints a funding URL for you to open in your browser
 
-**Options:**
-- `--address <fast-address>` — Fund a specific Fast address directly (otherwise uses the selected account)
-- `--network <name>` — Must be `mainnet`
+- Mainnet only (Ramp does not support testnet).
+- Active account or `--address <fast1...>`.
 
 ---
 
-### `fast fund crypto <amount>`
+### `fast fund usdc crypto <amount>`
 
-Bridge crypto from an EVM chain to the Fast network.
+Bridge USDC from an EVM chain to the Fast network. The deposit lands as
+**fastUSDC** on Fast.
 
 ```bash
-fast fund crypto 10.5 --chain arbitrum-sepolia --token USDC
+fast fund usdc crypto 10.5 --chain arbitrum-sepolia --token USDC
 ```
 
 **Positional arguments:**
-- `<amount>` — Human-readable amount
+
+- `<amount>` — Human-readable amount to bridge (e.g., `10.5`).
 
 **Options:**
-- `--chain <chain>` — Source EVM chain (required)
-- `--token <token>` — Token symbol or token ID (defaults to `USDC` / `testUSDC`)
-- `--eip-7702` — Use the smart deposit flow when supported
+
+- `--chain <chain>` — Source EVM chain (required).
+- `--token <token>` — Token symbol or token ID (defaults to `USDC` / `testUSDC`).
+- `--eip-7702` — Use the smart deposit flow (gas paid in USDC via paymaster).
+
+---
+
+### `fast fund fastusd`
+
+Print an `app.fast.xyz/send` URL that opens the unified Fast web app to fund
+your account with **fastUSD** (a Fast-native token, separate from fastUSDC).
+The web app handles fiat-onramp, crypto-bridge, and wallet-to-wallet funding
+under the hood; the CLI's job is just to produce the URL.
+
+```bash
+fast fund fastusd
+# → https://app.fast.xyz/send?to=fast1...
+
+fast fund fastusd --amount 25
+# → https://app.fast.xyz/send?to=fast1...&amount=25
+
+fast fund fastusd --to fast1someoneelse --amount 10
+# → https://app.fast.xyz/send?to=fast1someoneelse&amount=10
+```
+
+**Options:**
+
+- `--to <fast1...>` — Recipient Fast address (default: active account).
+- `--amount <decimal>` — Optional amount; if omitted, the web app prompts.
+
+**Requirements:**
+
+- Mainnet only.
 
 ---
 
@@ -285,9 +323,11 @@ fast pay https://api.example.com/premium
 ```
 
 **Positional arguments:**
+
 - `<url>` — URL of the x402-protected resource (required)
 
 **Options:**
+
 - `--dry-run` — Show payment details without actually paying
 - `--method <GET|POST|...>` — HTTP method (default: GET)
 - `--header <key:value>` — Custom request header (can be repeated)
@@ -324,12 +364,15 @@ fast network add my-custom-net --config ./network-config.json
 ```
 
 **Positional arguments:**
+
 - `<name>` — Unique name for the network
 
 **Options:**
+
 - `--config <path>` — Path to a JSON file with the network configuration (required)
 
 **Example JSON config (`network-config.json`):**
+
 ```json
 {
   "url": "https://api.fast.xyz/proxy-rest",
@@ -383,8 +426,11 @@ The CLI stores data in `~/.fast/`:
 # 1. Create an account
 fast account create --name my-account
 
-# 2. Get a fiat on-ramp URL
-fast fund fiat --network mainnet --address fast1...
+# 2. Get a fiat on-ramp URL (USDC → fastUSDC)
+fast fund usdc fiat --network mainnet --address fast1...
+
+# 2b. Or open the unified Fast web app to fund fastUSD
+fast fund fastusd --network mainnet
 
 # 3. Check your balance
 fast info balance --account my-account

--- a/app/cli/README.md
+++ b/app/cli/README.md
@@ -32,10 +32,10 @@ fast account create
 # Check balances
 fast info balance
 
-# Send USDC
-fast send fast1abc...xyz 10
+# Send USDC explicitly (omitting --token would default to fastUSD on mainnet)
+fast send fast1abc...xyz 10 --token USDC
 
-# Bridge from Arbitrum Sepolia to Fast (USDC → fastUSDC)
+# Bridge USDC from Arbitrum Sepolia to Fast
 fast fund usdc crypto 50 --chain arbitrum-sepolia
 
 # Or get a unified Fast web-app URL to fund fastUSD (mainnet only)
@@ -250,8 +250,8 @@ fast info bridge-tokens
 ### `fast fund usdc fiat`
 
 Get a fiat on-ramp URL for funding a Fast address with USDC. The URL targets
-[ramp.fast.xyz](https://ramp.fast.xyz). The deposit lands on Fast as
-**fastUSDC** (the EVM-bridged variant of USDC).
+[ramp.fast.xyz](https://ramp.fast.xyz); the deposit lands on Fast as bridged
+USDC, distinct from the Fast-native `fastUSD`.
 
 ```bash
 fast fund usdc fiat --network mainnet
@@ -267,7 +267,7 @@ fast fund usdc fiat --network mainnet
 ### `fast fund usdc crypto <amount>`
 
 Bridge USDC from an EVM chain to the Fast network. The deposit lands as
-**fastUSDC** on Fast.
+bridged USDC on Fast (distinct from `fastUSD`).
 
 ```bash
 fast fund usdc crypto 10.5 --chain arbitrum-sepolia --token USDC
@@ -288,7 +288,7 @@ fast fund usdc crypto 10.5 --chain arbitrum-sepolia --token USDC
 ### `fast fund fastusd`
 
 Print an `app.fast.xyz/send` URL that opens the unified Fast web app to fund
-your account with **fastUSD** (a Fast-native token, separate from fastUSDC).
+your account with **fastUSD** (a Fast-native token, separate from bridged USDC).
 The web app handles fiat-onramp, crypto-bridge, and wallet-to-wallet funding
 under the hood; the CLI's job is just to produce the URL.
 
@@ -426,7 +426,7 @@ The CLI stores data in `~/.fast/`:
 # 1. Create an account
 fast account create --name my-account
 
-# 2. Get a fiat on-ramp URL (USDC → fastUSDC)
+# 2. Get a fiat on-ramp URL (delivers USDC to your Fast account)
 fast fund usdc fiat --network mainnet --address fast1...
 
 # 2b. Or open the unified Fast web app to fund fastUSD

--- a/app/cli/package.json
+++ b/app/cli/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "tsup",
     "prepack": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run"
   },
   "dependencies": {
     "@clack/core": "^1.2.0",

--- a/app/cli/src/cli.ts
+++ b/app/cli/src/cli.ts
@@ -351,23 +351,23 @@ const sendParser = command(
 // Fund commands
 // ---------------------------------------------------------------------------
 
-const fundFiatParser = command(
+const fundUsdcFiatParser = command(
   "fiat",
   object({
-    cmd: constant("fund-fiat" as const),
+    cmd: constant("fund-usdc-fiat" as const),
     address: optional(
       option("--address", string({ metavar: "ADDRESS" }), {
         description: message`Fast address to fund (default: default account)`,
       }),
     ),
   }),
-  { description: message`Get a fiat on-ramp funding URL` },
+  { description: message`Get a fiat on-ramp funding URL (USDC via Ramp)` },
 );
 
-const fundCryptoParser = command(
+const fundUsdcCryptoParser = command(
   "crypto",
   object({
-    cmd: constant("fund-crypto" as const),
+    cmd: constant("fund-usdc-crypto" as const),
     amount: argument(string({ metavar: "AMOUNT" }), {
       description: message`Human-readable amount to fund (e.g., 100.00)`,
     }),
@@ -386,12 +386,38 @@ const fundCryptoParser = command(
       false,
     ),
   }),
-  { description: message`Fund Fast account by bridging from an EVM chain` },
+  { description: message`Bridge USDC from an EVM chain (lands as fastUSDC)` },
+);
+
+const fundUsdcGroup = command(
+  "usdc",
+  or(fundUsdcFiatParser, fundUsdcCryptoParser),
+  { description: message`Fund with USDC (lands as fastUSDC on Fast)` },
+);
+
+const fundFastUsdParser = command(
+  "fastusd",
+  object({
+    cmd: constant("fund-fastusd" as const),
+    to: optional(
+      option("--to", string({ metavar: "ADDRESS" }), {
+        description: message`Fast address to fund (default: default account)`,
+      }),
+    ),
+    amount: optional(
+      option("--amount", string({ metavar: "AMOUNT" }), {
+        description: message`Optional amount (decimal, e.g. 10.5)`,
+      }),
+    ),
+  }),
+  {
+    description: message`Print a Fast web-app URL to fund your account with fastUSD (mainnet only)`,
+  },
 );
 
 const fundGroup = command(
   "fund",
-  or(fundFiatParser, fundCryptoParser),
+  or(fundUsdcGroup, fundFastUsdParser),
   { description: message`Fund your account` },
 );
 
@@ -468,8 +494,9 @@ export type InfoBridgeChainsArgs = InferValue<typeof infoBridgeChainsParser>;
 
 export type SendArgs = InferValue<typeof sendParser>;
 
-export type FundFiatArgs = InferValue<typeof fundFiatParser>;
-export type FundCryptoArgs = InferValue<typeof fundCryptoParser>;
+export type FundUsdcFiatArgs = InferValue<typeof fundUsdcFiatParser>;
+export type FundUsdcCryptoArgs = InferValue<typeof fundUsdcCryptoParser>;
+export type FundFastUsdArgs = InferValue<typeof fundFastUsdParser>;
 export type PayArgs = InferValue<typeof payParser>;
 
 /** The full parsed result: global options merged with the chosen command. */

--- a/app/cli/src/cli.ts
+++ b/app/cli/src/cli.ts
@@ -386,13 +386,13 @@ const fundUsdcCryptoParser = command(
       false,
     ),
   }),
-  { description: message`Bridge USDC from an EVM chain (lands as fastUSDC)` },
+  { description: message`Bridge USDC from an EVM chain into your Fast account` },
 );
 
 const fundUsdcGroup = command(
   "usdc",
   or(fundUsdcFiatParser, fundUsdcCryptoParser),
-  { description: message`Fund with USDC (lands as fastUSDC on Fast)` },
+  { description: message`Fund your Fast account with USDC (fiat or crypto)` },
 );
 
 const fundFastUsdParser = command(

--- a/app/cli/src/commands/fund/fastusd-url.ts
+++ b/app/cli/src/commands/fund/fastusd-url.ts
@@ -1,0 +1,16 @@
+const APP_BASE = "https://app.fast.xyz/send";
+
+/**
+ * Build the `app.fast.xyz/send` URL that opens the unified Fast funding flow.
+ * The web app accepts both query params as optional and prompts the user when missing.
+ */
+export function buildFundFastUsdUrl(
+  to: string,
+  amount: string | undefined,
+): string {
+  const params = new URLSearchParams({ to });
+  if (amount !== undefined) {
+    params.set("amount", amount);
+  }
+  return `${APP_BASE}?${params.toString()}`;
+}

--- a/app/cli/src/commands/fund/fastusd.ts
+++ b/app/cli/src/commands/fund/fastusd.ts
@@ -1,0 +1,66 @@
+import { Effect } from "effect";
+import type { FundFastUsdArgs } from "../../cli.js";
+import { InvalidAddressError, InvalidAmountError, InvalidUsageError } from "../../errors/index.js";
+import { ClientConfig } from "../../services/config/client.js";
+import { Output } from "../../services/output.js";
+import { AccountStore } from "../../services/storage/account.js";
+import type { Command } from "../index.js";
+import { buildFundFastUsdUrl } from "./fastusd-url.js";
+
+const isPositiveDecimal = (s: string): boolean => {
+  if (s.trim() === "") return false;
+  if (!/^\d+(\.\d+)?$/.test(s)) return false;
+  return Number.parseFloat(s) > 0;
+};
+
+export const fundFastUsd: Command<FundFastUsdArgs> = {
+  cmd: "fund-fastusd",
+  handler: (args) =>
+    Effect.gen(function* () {
+      const accounts = yield* AccountStore;
+      const output = yield* Output;
+      const config = yield* ClientConfig;
+
+      if (config.network !== "mainnet") {
+        return yield* Effect.fail(
+          new InvalidUsageError({
+            message:
+              `fastUSD funding is only available on mainnet. ` +
+              `Current network: ${config.network}. ` +
+              `Switch with --network mainnet.`,
+          }),
+        );
+      }
+
+      let address: string;
+      if (args.to) {
+        if (!args.to.startsWith("fast1")) {
+          return yield* Effect.fail(
+            new InvalidAddressError({
+              message: `Invalid Fast address "${args.to}". Must start with fast1.`,
+            }),
+          );
+        }
+        address = args.to;
+      } else {
+        const account = yield* accounts.resolveAccount(config.account);
+        address = account.fastAddress;
+      }
+
+      if (args.amount !== undefined && !isPositiveDecimal(args.amount)) {
+        return yield* Effect.fail(
+          new InvalidAmountError({
+            message: `Invalid amount "${args.amount}". Expected a positive decimal (e.g. 10 or 1.5).`,
+          }),
+        );
+      }
+
+      const url = buildFundFastUsdUrl(address, args.amount);
+
+      yield* output.humanLine("Open this URL in your browser to fund your account:");
+      yield* output.humanLine("");
+      yield* output.humanLine(`  ${url}`);
+      yield* output.humanLine("");
+      yield* output.ok({ url, address });
+    }),
+};

--- a/app/cli/src/commands/fund/usdc/crypto.ts
+++ b/app/cli/src/commands/fund/usdc/crypto.ts
@@ -6,28 +6,28 @@ import {
 } from "@fastxyz/allset-sdk";
 import { toHex } from "@fastxyz/sdk";
 import { Effect } from "effect";
-import type { FundCryptoArgs } from "../../cli.js";
+import type { FundUsdcCryptoArgs } from "../../../cli.js";
 import {
   FundingRequiredError,
   InvalidAmountError,
   InvalidNetworkConfigError,
   TransactionFailedError,
   UnsupportedChainError,
-} from "../../errors/index.js";
-import { makeHistoryEntry } from "../../schemas/history.js";
-import { AllSet } from "../../services/api/allset.js";
-import { ClientConfig } from "../../services/config/client.js";
-import { Output } from "../../services/output.js";
-import { Prompt } from "../../services/prompt.js";
-import { AccountStore } from "../../services/storage/account.js";
-import { HistoryStore } from "../../services/storage/history.js";
-import { NetworkConfigService } from "../../services/storage/network.js";
-import { resolveToken } from "../../services/token-resolver.js";
-import type { Command } from "../index.js";
+} from "../../../errors/index.js";
+import { makeHistoryEntry } from "../../../schemas/history.js";
+import { AllSet } from "../../../services/api/allset.js";
+import { ClientConfig } from "../../../services/config/client.js";
+import { Output } from "../../../services/output.js";
+import { Prompt } from "../../../services/prompt.js";
+import { AccountStore } from "../../../services/storage/account.js";
+import { HistoryStore } from "../../../services/storage/history.js";
+import { NetworkConfigService } from "../../../services/storage/network.js";
+import { resolveToken } from "../../../services/token-resolver.js";
+import type { Command } from "../../index.js";
 
-export const fundCrypto: Command<FundCryptoArgs> = {
-  cmd: "fund-crypto",
-  handler: (args: FundCryptoArgs) =>
+export const fundUsdcCrypto: Command<FundUsdcCryptoArgs> = {
+  cmd: "fund-usdc-crypto",
+  handler: (args: FundUsdcCryptoArgs) =>
     Effect.gen(function* () {
       const accounts = yield* AccountStore;
       const bridge = yield* AllSet;

--- a/app/cli/src/commands/fund/usdc/fiat-url.ts
+++ b/app/cli/src/commands/fund/usdc/fiat-url.ts
@@ -1,0 +1,11 @@
+const RAMP_BASE = "https://ramp.fast.xyz";
+
+/**
+ * Build the `ramp.fast.xyz` URL for the fiat on-ramp flow.
+ * Uses URLSearchParams so the address can't be smuggled as raw query text
+ * (e.g. an address containing `&to=other` would otherwise produce duplicate params).
+ */
+export function buildRampUrl(toAddress: string): string {
+  const params = new URLSearchParams({ to: toAddress });
+  return `${RAMP_BASE}/?${params.toString()}`;
+}

--- a/app/cli/src/commands/fund/usdc/fiat.ts
+++ b/app/cli/src/commands/fund/usdc/fiat.ts
@@ -1,15 +1,15 @@
 import { Effect } from "effect";
-import type { FundFiatArgs } from "../../cli.js";
-import { InvalidAddressError, InvalidUsageError } from "../../errors/index.js";
-import { ClientConfig } from "../../services/config/client.js";
-import { Output } from "../../services/output.js";
-import { AccountStore } from "../../services/storage/account.js";
-import type { Command } from "../index.js";
+import type { FundUsdcFiatArgs } from "../../../cli.js";
+import { InvalidAddressError, InvalidUsageError } from "../../../errors/index.js";
+import { ClientConfig } from "../../../services/config/client.js";
+import { Output } from "../../../services/output.js";
+import { AccountStore } from "../../../services/storage/account.js";
+import type { Command } from "../../index.js";
 
 const RAMP_BASE = "https://ramp.fast.xyz";
 
-export const fundFiat: Command<FundFiatArgs> = {
-  cmd: "fund-fiat",
+export const fundUsdcFiat: Command<FundUsdcFiatArgs> = {
+  cmd: "fund-usdc-fiat",
   handler: (args) =>
     Effect.gen(function* () {
       const accounts = yield* AccountStore;

--- a/app/cli/src/commands/fund/usdc/fiat.ts
+++ b/app/cli/src/commands/fund/usdc/fiat.ts
@@ -46,6 +46,6 @@ export const fundUsdcFiat: Command<FundUsdcFiatArgs> = {
       yield* output.humanLine(`  ${url}`);
       yield* output.humanLine("");
 
-      yield* output.ok({ url, address, tokenName: "USDC" });
+      yield* output.ok({ url, address, tokenName: "fastUSDC" });
     }),
 };

--- a/app/cli/src/commands/fund/usdc/fiat.ts
+++ b/app/cli/src/commands/fund/usdc/fiat.ts
@@ -1,3 +1,4 @@
+import { fromFastAddress } from "@fastxyz/sdk";
 import { Effect } from "effect";
 import type { FundUsdcFiatArgs } from "../../../cli.js";
 import { InvalidAddressError, InvalidUsageError } from "../../../errors/index.js";
@@ -5,8 +6,16 @@ import { ClientConfig } from "../../../services/config/client.js";
 import { Output } from "../../../services/output.js";
 import { AccountStore } from "../../../services/storage/account.js";
 import type { Command } from "../../index.js";
+import { buildRampUrl } from "./fiat-url.js";
 
-const RAMP_BASE = "https://ramp.fast.xyz";
+const isValidFastAddress = (address: string): boolean => {
+  try {
+    fromFastAddress(address);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 export const fundUsdcFiat: Command<FundUsdcFiatArgs> = {
   cmd: "fund-usdc-fiat",
@@ -26,10 +35,10 @@ export const fundUsdcFiat: Command<FundUsdcFiatArgs> = {
 
       let address: string;
       if (args.address) {
-        if (!args.address.startsWith("fast1")) {
+        if (!isValidFastAddress(args.address)) {
           return yield* Effect.fail(
             new InvalidAddressError({
-              message: `Invalid Fast address "${args.address}". Must start with fast1.`,
+              message: `Invalid Fast address "${args.address}". Must be a valid bech32m address with the "fast" prefix.`,
             }),
           );
         }
@@ -39,13 +48,13 @@ export const fundUsdcFiat: Command<FundUsdcFiatArgs> = {
         address = account.fastAddress;
       }
 
-      const url = `${RAMP_BASE}/?to=${address}`;
+      const url = buildRampUrl(address);
 
       yield* output.humanLine("Open this URL in your browser to fund your account:");
       yield* output.humanLine("");
       yield* output.humanLine(`  ${url}`);
       yield* output.humanLine("");
 
-      yield* output.ok({ url, address, tokenName: "fastUSDC" });
+      yield* output.ok({ url, address, tokenName: "USDC" });
     }),
 };

--- a/app/cli/src/commands/index.ts
+++ b/app/cli/src/commands/index.ts
@@ -7,6 +7,9 @@ import { accountExport } from "./account/export.js";
 import { accountImport } from "./account/import.js";
 import { accountList } from "./account/list.js";
 import { accountSetDefault } from "./account/set-default.js";
+import { fundFastUsd } from "./fund/fastusd.js";
+import { fundUsdcCrypto } from "./fund/usdc/crypto.js";
+import { fundUsdcFiat } from "./fund/usdc/fiat.js";
 import { infoBalance } from "./info/balance.js";
 import { infoBridgeChains } from "./info/bridge-chains.js";
 import { infoBridgeTokens } from "./info/bridge-tokens.js";
@@ -17,8 +20,6 @@ import { networkAdd } from "./network/add.js";
 import { networkList } from "./network/list.js";
 import { networkRemove } from "./network/remove.js";
 import { networkSetDefault } from "./network/set-default.js";
-import { fundCrypto } from "./fund/crypto.js";
-import { fundFiat } from "./fund/fiat.js";
 import { pay } from "./pay.js";
 import { send } from "./send.js";
 
@@ -29,8 +30,9 @@ export const commands = [
   accountImport,
   accountList,
   accountSetDefault,
-  fundCrypto,
-  fundFiat,
+  fundFastUsd,
+  fundUsdcCrypto,
+  fundUsdcFiat,
   infoBalance,
   infoBridgeChains,
   infoBridgeTokens,

--- a/app/cli/src/commands/pay-asset-label.ts
+++ b/app/cli/src/commands/pay-asset-label.ts
@@ -1,0 +1,19 @@
+import type { NetworkConfig } from "../schemas/networks.js";
+import { lookupTokenNameById } from "../services/token-resolver.js";
+
+/**
+ * Translate a server-supplied asset hex into a display string for the pay
+ * dry-run printer and the history entry's `tokenName` column.
+ *
+ * - undefined / "" → "unknown"
+ * - registered → the registry's display name (e.g. "fastUSD", "USDC")
+ * - unregistered hex → the hex itself (so callers can still trace it on-chain)
+ */
+export function labelAssetForPayment(
+  networkConfig: NetworkConfig,
+  asset: string | undefined,
+): string {
+  if (!asset) return "unknown";
+  const name = lookupTokenNameById(networkConfig, asset);
+  return name ?? asset;
+}

--- a/app/cli/src/commands/pay.ts
+++ b/app/cli/src/commands/pay.ts
@@ -183,7 +183,7 @@ export const pay: Command<PayArgs> = {
             amount: p.amount,
             formatted: p.amount,
             tokenName: labelAssetForPayment(network, p.asset),
-            tokenId: "",
+            tokenId: p.asset ?? "",
             network: p.network,
             status: "confirmed",
             timestamp: new Date().toISOString(),

--- a/app/cli/src/commands/pay.ts
+++ b/app/cli/src/commands/pay.ts
@@ -14,6 +14,7 @@ import { AccountStore } from "../services/storage/account.js";
 import { HistoryStore } from "../services/storage/history.js";
 import { NetworkConfigService } from "../services/storage/network.js";
 import type { Command } from "./index.js";
+import { labelAssetForPayment } from "./pay-asset-label.js";
 
 const parseHeaders = (raw: readonly string[]): Record<string, string> => {
   const headers: Record<string, string> = {};
@@ -54,6 +55,7 @@ export const pay: Command<PayArgs> = {
 
       const headers = parseHeaders(args.header);
       const body = yield* resolveBody(args.body);
+      const network = yield* networkConfig.resolve(config.network);
 
       // Validate inputs
       const urlErr = validateUrl(args.url);
@@ -91,7 +93,9 @@ export const pay: Command<PayArgs> = {
           yield* output.humanLine(`  Network: ${opt.network}`);
           yield* output.humanLine(`  Amount:  ${opt.maxAmountRequired}`);
           yield* output.humanLine(`  Pay to:  ${opt.payTo}`);
-          yield* output.humanLine(`  Asset:   ${opt.asset ?? "USDC"}`);
+          yield* output.humanLine(
+            `  Asset:   ${labelAssetForPayment(network, opt.asset)}`,
+          );
           yield* output.humanLine("");
         }
         yield* output.ok({
@@ -103,7 +107,6 @@ export const pay: Command<PayArgs> = {
       }
 
       // -- Normal mode: resolve account + wallets --
-      const network = yield* networkConfig.resolve(config.network);
       const accountInfo = yield* accounts.resolveAccount(config.account);
       const pwd = accountInfo.encrypted
         ? yield* prompt.password()
@@ -179,7 +182,7 @@ export const pay: Command<PayArgs> = {
             to: p.recipient,
             amount: p.amount,
             formatted: p.amount,
-            tokenName: "USDC",
+            tokenName: labelAssetForPayment(network, p.asset),
             tokenId: "",
             network: p.network,
             status: "confirmed",

--- a/app/cli/src/commands/send-token-helper.ts
+++ b/app/cli/src/commands/send-token-helper.ts
@@ -1,14 +1,17 @@
 import type { NetworkConfig } from "../schemas/networks.js";
-import { resolveDefaultToken } from "../services/token-resolver.js";
+import { pickDefaultTokenName } from "../services/token-resolver.js";
 
 /**
  * Pick the token NAME (a string the resolver later maps to a ResolvedToken) for
  * a `send` invocation given the user's --token flag and bridge chain context.
+ * Pure name-selection: never decodes token IDs, never throws. Any decode/lookup
+ * failure surfaces from the caller's `resolveToken(...)` step instead.
  *
  * - Explicit --token wins.
- * - With chain context (--from-chain / --to-chain): default to first token on that
- *   chain, falling back to "USDC" only if the chain config is somehow empty.
- * - Without chain context (Fast→Fast): use resolveDefaultToken (prefers fastTokens.fastUSD on mainnet).
+ * - With chain context (--from-chain / --to-chain): default to first token on
+ *   that chain, falling back to "USDC" if the chain config is somehow empty.
+ * - Without chain context (Fast→Fast): pick `fastTokens.fastUSD` if present,
+ *   otherwise the network's first registered token, falling back to "USDC".
  */
 export function selectSendTokenName(
   explicit: string | undefined,
@@ -23,5 +26,5 @@ export function selectSendTokenName(
     return first ?? "USDC";
   }
 
-  return resolveDefaultToken(networkConfig).name;
+  return pickDefaultTokenName(networkConfig) ?? "USDC";
 }

--- a/app/cli/src/commands/send-token-helper.ts
+++ b/app/cli/src/commands/send-token-helper.ts
@@ -1,0 +1,27 @@
+import type { NetworkConfig } from "../schemas/networks.js";
+import { resolveDefaultToken } from "../services/token-resolver.js";
+
+/**
+ * Pick the token NAME (a string the resolver later maps to a ResolvedToken) for
+ * a `send` invocation given the user's --token flag and bridge chain context.
+ *
+ * - Explicit --token wins.
+ * - With chain context (--from-chain / --to-chain): default to first token on that
+ *   chain, falling back to "USDC" only if the chain config is somehow empty.
+ * - Without chain context (Fast→Fast): use resolveDefaultToken (prefers fastTokens.fastUSD on mainnet).
+ */
+export function selectSendTokenName(
+  explicit: string | undefined,
+  networkConfig: NetworkConfig,
+  chain: string | undefined,
+): string {
+  if (explicit !== undefined) return explicit;
+
+  if (chain) {
+    const chainCfg = networkConfig.allSet?.chains[chain];
+    const first = chainCfg ? Object.keys(chainCfg.tokens)[0] : undefined;
+    return first ?? "USDC";
+  }
+
+  return resolveDefaultToken(networkConfig).name;
+}

--- a/app/cli/src/commands/send.ts
+++ b/app/cli/src/commands/send.ts
@@ -33,6 +33,7 @@ import { AccountStore } from "../services/storage/account.js";
 import { HistoryStore } from "../services/storage/history.js";
 import { NetworkConfigService } from "../services/storage/network.js";
 import { resolveToken } from "../services/token-resolver.js";
+import { selectSendTokenName } from "./send-token-helper.js";
 import type { Command } from "./index.js";
 
 export const send: Command<SendArgs> = {
@@ -120,15 +121,7 @@ export const send: Command<SendArgs> = {
 
       // Resolve token name: use provided value or default to first token on the network
       const tokenChain = fromChain ?? toChain;
-      const resolvedTokenName =
-        args.token ??
-        (() => {
-          const chains = network.allSet?.chains ?? {};
-          const firstChain = Object.values(chains)[0];
-          return firstChain
-            ? (Object.keys(firstChain.tokens)[0] ?? "USDC")
-            : "USDC";
-        })();
+      const resolvedTokenName = selectSendTokenName(args.token, network, tokenChain);
 
       // Resolve token using the appropriate chain context
       const tokenInfo = yield* Effect.try({

--- a/app/cli/src/config/networks.ts
+++ b/app/cli/src/config/networks.ts
@@ -98,5 +98,11 @@ export const bundledNetworks: Record<string, NetworkConfig> = {
         },
       },
     },
+    fastTokens: {
+      fastUSD: {
+        fastTokenId: "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+        decimals: 6,
+      },
+    },
   },
 };

--- a/app/cli/src/main.ts
+++ b/app/cli/src/main.ts
@@ -154,7 +154,7 @@ const SUBCOMMANDS: Record<string, readonly string[]> = {
   account: ["create", "import", "list", "set-default", "export", "delete"],
   network: ["list", "add", "set-default", "remove"],
   info: ["status", "balance", "tx", "history", "bridge-tokens", "bridge-chains"],
-  fund: ["fiat", "crypto"],
+  fund: ["usdc", "fastusd"],
 };
 
 /** Simple Levenshtein distance for short strings. */
@@ -220,19 +220,35 @@ const SUBCOMMAND_REQUIREMENTS: Record<
     },
   },
   // ── Subcommands with required args/options ─────────────────────────────────
-  "fund crypto": {
-    usage: "fast fund crypto <amount> --chain <chain> [--token <token>]",
+  "fund usdc": {
+    usage: "fast fund usdc <fiat|crypto>",
+    options: [],
+    check: (positionals) => {
+      const third = positionals[2];
+      if (!third) return "Missing subcommand. Available: fiat, crypto";
+      if (third !== "fiat" && third !== "crypto")
+        return `Unknown subcommand '${third}' for 'fund usdc'. Available: fiat, crypto`;
+      return null;
+    },
+  },
+  "fund usdc fiat": {
+    usage: "fast fund usdc fiat [--address <address>]",
+    options: ["--address"],
+    check: () => null,
+  },
+  "fund usdc crypto": {
+    usage: "fast fund usdc crypto <amount> --chain <chain> [--token <token>]",
     options: ["--chain", "--token", "--eip-7702"],
     check: (positionals, allArgv) => {
-      if (positionals.length < 3) return "Missing required argument: <amount>";
+      if (positionals.length < 4) return "Missing required argument: <amount>";
       if (!allArgv.some((a) => a === "--chain" || a.startsWith("--chain=")))
         return "Missing required option: --chain <chain>";
       return null;
     },
   },
-  "fund fiat": {
-    usage: "fast fund fiat [--address <address>]",
-    options: ["--address"],
+  "fund fastusd": {
+    usage: "fast fund fastusd [--to <fast1...>] [--amount <decimal>]",
+    options: ["--to", "--amount"],
     check: () => null,
   },
   "network add": {
@@ -349,8 +365,13 @@ if (!result.success) {
         ? `Unknown subcommand '${secondToken}' for '${firstToken}'. Did you mean '${s}'?`
         : `Unknown subcommand '${secondToken}' for '${firstToken}'. Available: ${subs.join(", ")}.`;
     } else {
-      // Valid subcommand but parse still failed — check for missing required args/options
-      const key = `${firstToken} ${secondToken}`;
+      // Try the deepest matching key (3-deep first, then 2-deep) so e.g.
+      // `fund usdc fiat` matches "fund usdc fiat" not "fund usdc".
+      const thirdToken = positionals[2];
+      const deepKey = thirdToken ? `${firstToken} ${secondToken} ${thirdToken}` : null;
+      const shallowKey = `${firstToken} ${secondToken}`;
+      const key =
+        deepKey && deepKey in SUBCOMMAND_REQUIREMENTS ? deepKey : shallowKey;
       const req = SUBCOMMAND_REQUIREMENTS[key];
       if (req) {
         const hint = req.check(positionals, argv);

--- a/app/cli/src/schemas/networks.ts
+++ b/app/cli/src/schemas/networks.ts
@@ -26,11 +26,20 @@ export const AllSetConfigSchema = Schema.Struct({
 });
 export type AllSetConfig = typeof AllSetConfigSchema.Type;
 
+export const FastTokenSchema = Schema.Struct({
+  fastTokenId: Schema.String,
+  decimals: Schema.Number,
+});
+export type FastTokenConfig = typeof FastTokenSchema.Type;
+
 export const NetworkConfigSchema = Schema.Struct({
   url: Schema.String,
   explorerUrl: Schema.String,
   networkId: NetworkId,
   allSet: Schema.optional(AllSetConfigSchema),
+  fastTokens: Schema.optional(
+    Schema.Record({ key: Schema.String, value: FastTokenSchema }),
+  ),
 });
 export type NetworkConfig = typeof NetworkConfigSchema.Type;
 

--- a/app/cli/src/services/token-resolver.ts
+++ b/app/cli/src/services/token-resolver.ts
@@ -64,32 +64,24 @@ export function resolveToken(
 }
 
 /**
- * Resolve the implicit default token for a Fast→Fast operation.
- * Prefers `fastTokens.fastUSD`, then any single `fastTokens` entry,
- * then the first chain's first token. Throws TokenNotFoundError if none.
+ * Pure name-selection: pick the implicit default token NAME for a Fast→Fast
+ * operation without decoding any token IDs. Never throws.
+ *
+ * Priority: `fastTokens.fastUSD` → single `fastTokens` entry → first chain's
+ * first token → `undefined` (no token registered for this network).
+ *
+ * Callers that need the decoded `ResolvedToken` should follow up with
+ * `resolveToken(name, network)` inside their existing error wrapper, so any
+ * decode failure flows through the normal CLI error path.
  */
-export function resolveDefaultToken(networkConfig: NetworkConfig): {
-  readonly name: string;
-  readonly token: ResolvedToken;
-} {
+export function pickDefaultTokenName(
+  networkConfig: NetworkConfig,
+): string | undefined {
   const fast = networkConfig.fastTokens;
   if (fast) {
-    if ("fastUSD" in fast) {
-      const t = fast.fastUSD!;
-      return {
-        name: "fastUSD",
-        token: { fastTokenId: fromHex(t.fastTokenId), decimals: t.decimals },
-      };
-    }
+    if ("fastUSD" in fast) return "fastUSD";
     const keys = Object.keys(fast);
-    if (keys.length === 1) {
-      const name = keys[0]!;
-      const t = fast[name]!;
-      return {
-        name,
-        token: { fastTokenId: fromHex(t.fastTokenId), decimals: t.decimals },
-      };
-    }
+    if (keys.length === 1) return keys[0];
     // Multiple entries, none called "fastUSD" — ambiguous, fall through.
   }
 
@@ -97,21 +89,27 @@ export function resolveDefaultToken(networkConfig: NetworkConfig): {
   if (allset) {
     const firstChain = Object.values(allset.chains)[0];
     if (firstChain) {
-      const firstName = Object.keys(firstChain.tokens)[0];
-      if (firstName) {
-        const token = firstChain.tokens[firstName]!;
-        return {
-          name: firstName,
-          token: {
-            fastTokenId: fromHex(token.fastTokenId),
-            decimals: token.decimals,
-          },
-        };
-      }
+      return Object.keys(firstChain.tokens)[0];
     }
   }
 
-  throw new TokenNotFoundError({ token: "<default>" });
+  return undefined;
+}
+
+/**
+ * Resolve the implicit default token (name + decoded ResolvedToken) for a
+ * Fast→Fast operation. Throws TokenNotFoundError if none is registered, or
+ * propagates `fromHex` failures on malformed `fastTokenId` values.
+ */
+export function resolveDefaultToken(networkConfig: NetworkConfig): {
+  readonly name: string;
+  readonly token: ResolvedToken;
+} {
+  const name = pickDefaultTokenName(networkConfig);
+  if (name === undefined) {
+    throw new TokenNotFoundError({ token: "<default>" });
+  }
+  return { name, token: resolveToken(name, networkConfig) };
 }
 
 /** Normalise a hex string for comparison: strip leading 0x and lowercase. */

--- a/app/cli/src/services/token-resolver.ts
+++ b/app/cli/src/services/token-resolver.ts
@@ -9,22 +9,21 @@ export interface ResolvedToken {
 }
 
 /**
- * Resolves a token name to its fastTokenId, decimals, and (for bridge tokens) evmAddress.
+ * Map a token name to its on-Fast id, decimals, and (when bridging) EVM address.
  *
- * If `chain` is provided (bridge route), look up the token in that specific chain's config.
- * If `chain` is omitted (Fast→Fast route), scan all chains and return the first match.
+ * - With chain context (bridge route): only chain-scoped `allSet.chains[chain].tokens` is consulted.
+ * - Without chain context (Fast→Fast): `network.fastTokens` is consulted first, then chain-scoped tokens.
  */
 export function resolveToken(
   tokenName: string,
   networkConfig: NetworkConfig,
   chain?: string,
 ): ResolvedToken {
-  const allset = networkConfig.allSet;
-  if (!allset) {
-    throw new TokenNotFoundError({ token: tokenName });
-  }
-
   if (chain) {
+    const allset = networkConfig.allSet;
+    if (!allset) {
+      throw new TokenNotFoundError({ token: tokenName });
+    }
     const chainConfig = allset.chains[chain];
     if (!chainConfig) {
       throw new UnsupportedChainError({ chain });
@@ -40,16 +39,111 @@ export function resolveToken(
     };
   }
 
-  // Fast→Fast: scan all chains for the token
-  for (const chainConfig of Object.values(allset.chains)) {
-    const token = chainConfig.tokens[tokenName];
-    if (token) {
-      return {
-        fastTokenId: fromHex(token.fastTokenId),
-        decimals: token.decimals,
-      };
+  const fast = networkConfig.fastTokens?.[tokenName];
+  if (fast) {
+    return {
+      fastTokenId: fromHex(fast.fastTokenId),
+      decimals: fast.decimals,
+    };
+  }
+
+  const allset = networkConfig.allSet;
+  if (allset) {
+    for (const chainConfig of Object.values(allset.chains)) {
+      const token = chainConfig.tokens[tokenName];
+      if (token) {
+        return {
+          fastTokenId: fromHex(token.fastTokenId),
+          decimals: token.decimals,
+        };
+      }
     }
   }
 
   throw new TokenNotFoundError({ token: tokenName });
+}
+
+/**
+ * Resolve the implicit default token for a Fast→Fast operation.
+ * Prefers `fastTokens.fastUSD`, then any single `fastTokens` entry,
+ * then the first chain's first token. Throws TokenNotFoundError if none.
+ */
+export function resolveDefaultToken(networkConfig: NetworkConfig): {
+  readonly name: string;
+  readonly token: ResolvedToken;
+} {
+  const fast = networkConfig.fastTokens;
+  if (fast) {
+    if ("fastUSD" in fast) {
+      const t = fast.fastUSD!;
+      return {
+        name: "fastUSD",
+        token: { fastTokenId: fromHex(t.fastTokenId), decimals: t.decimals },
+      };
+    }
+    const keys = Object.keys(fast);
+    if (keys.length === 1) {
+      const name = keys[0]!;
+      const t = fast[name]!;
+      return {
+        name,
+        token: { fastTokenId: fromHex(t.fastTokenId), decimals: t.decimals },
+      };
+    }
+    // Multiple entries, none called "fastUSD" — ambiguous, fall through.
+  }
+
+  const allset = networkConfig.allSet;
+  if (allset) {
+    const firstChain = Object.values(allset.chains)[0];
+    if (firstChain) {
+      const firstName = Object.keys(firstChain.tokens)[0];
+      if (firstName) {
+        const token = firstChain.tokens[firstName]!;
+        return {
+          name: firstName,
+          token: {
+            fastTokenId: fromHex(token.fastTokenId),
+            decimals: token.decimals,
+          },
+        };
+      }
+    }
+  }
+
+  throw new TokenNotFoundError({ token: "<default>" });
+}
+
+/** Normalise a hex string for comparison: strip leading 0x and lowercase. */
+const norm = (h: string): string =>
+  (h.startsWith("0x") || h.startsWith("0X") ? h.slice(2) : h).toLowerCase();
+
+/**
+ * Inverse of resolveToken: given a fastTokenId hex (server's payment requirement),
+ * return the registered display name. Searches `fastTokens` then `allSet.chains[*].tokens`.
+ * Returns undefined when no entry matches.
+ */
+export function lookupTokenNameById(
+  networkConfig: NetworkConfig,
+  fastTokenId: string,
+): string | undefined {
+  const target = norm(fastTokenId);
+
+  const fast = networkConfig.fastTokens;
+  if (fast) {
+    for (const [name, entry] of Object.entries(fast)) {
+      if (norm(entry.fastTokenId) === target) return name;
+    }
+  }
+
+  const allset = networkConfig.allSet;
+  if (allset) {
+    for (const chain of Object.values(allset.chains)) {
+      for (const [name, entry] of Object.entries(chain.tokens)) {
+        if (norm(entry.fastTokenId) === target) return name;
+      }
+    }
+  }
+
+  return undefined;
 }

--- a/app/cli/tests/commands/fund-fastusd.test.ts
+++ b/app/cli/tests/commands/fund-fastusd.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { buildFundFastUsdUrl } from "../../src/commands/fund/fastusd-url.js";
+
+describe("buildFundFastUsdUrl", () => {
+  it("emits to= when only address is provided", () => {
+    expect(buildFundFastUsdUrl("fast1abc", undefined)).toBe(
+      "https://app.fast.xyz/send?to=fast1abc",
+    );
+  });
+
+  it("emits both to= and amount= when both are provided", () => {
+    expect(buildFundFastUsdUrl("fast1abc", "10")).toBe(
+      "https://app.fast.xyz/send?to=fast1abc&amount=10",
+    );
+  });
+
+  it("preserves a decimal amount unchanged", () => {
+    expect(buildFundFastUsdUrl("fast1abc", "10.5")).toBe(
+      "https://app.fast.xyz/send?to=fast1abc&amount=10.5",
+    );
+  });
+
+  it("URL-encodes special characters in the address", () => {
+    expect(buildFundFastUsdUrl("fast1abc def", "10")).toBe(
+      "https://app.fast.xyz/send?to=fast1abc+def&amount=10",
+    );
+  });
+});

--- a/app/cli/tests/commands/fund-usdc-fiat.test.ts
+++ b/app/cli/tests/commands/fund-usdc-fiat.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { buildRampUrl } from "../../src/commands/fund/usdc/fiat-url.js";
+
+describe("buildRampUrl", () => {
+  it("encodes a plain fast address as the to= query param", () => {
+    expect(buildRampUrl("fast1abc")).toBe("https://ramp.fast.xyz/?to=fast1abc");
+  });
+
+  it("encodes special characters so an injected `&to=` cannot smuggle a second param", () => {
+    expect(buildRampUrl("fast1x&to=fast1attacker")).toBe(
+      "https://ramp.fast.xyz/?to=fast1x%26to%3Dfast1attacker",
+    );
+  });
+});

--- a/app/cli/tests/commands/pay-asset-label.test.ts
+++ b/app/cli/tests/commands/pay-asset-label.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { labelAssetForPayment } from "../../src/commands/pay-asset-label.js";
+import type { NetworkConfig } from "../../src/schemas/networks.js";
+
+const MAINNET: NetworkConfig = {
+  url: "https://api.fast.xyz/proxy-rest",
+  explorerUrl: "https://explorer.fast.xyz",
+  networkId: "fast:mainnet",
+  fastTokens: {
+    fastUSD: {
+      fastTokenId:
+        "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+      decimals: 6,
+    },
+  },
+};
+
+describe("labelAssetForPayment", () => {
+  it("returns the registered token name when asset matches", () => {
+    expect(
+      labelAssetForPayment(
+        MAINNET,
+        "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+      ),
+    ).toBe("fastUSD");
+  });
+
+  it("returns 'unknown' when asset is undefined", () => {
+    expect(labelAssetForPayment(MAINNET, undefined)).toBe("unknown");
+  });
+
+  it("returns the short hex when asset is unknown", () => {
+    expect(labelAssetForPayment(MAINNET, "0xdeadbeefcafe1234")).toBe(
+      "0xdeadbeefcafe1234",
+    );
+  });
+
+  it("returns the empty-string fallback as 'unknown'", () => {
+    expect(labelAssetForPayment(MAINNET, "")).toBe("unknown");
+  });
+});

--- a/app/cli/tests/commands/send-default-token.test.ts
+++ b/app/cli/tests/commands/send-default-token.test.ts
@@ -60,7 +60,7 @@ const TESTNET: NetworkConfig = {
 
 describe("selectSendTokenName (send default-token logic)", () => {
   it("returns explicit token when provided (mainnet)", () => {
-    expect(selectSendTokenName("fastUSDC", MAINNET, undefined)).toBe("fastUSDC");
+    expect(selectSendTokenName("USDC", MAINNET, undefined)).toBe("USDC");
   });
 
   it("returns fastUSD on mainnet when token is omitted and no chain", () => {

--- a/app/cli/tests/commands/send-default-token.test.ts
+++ b/app/cli/tests/commands/send-default-token.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { selectSendTokenName } from "../../src/commands/send-token-helper.js";
+import type { NetworkConfig } from "../../src/schemas/networks.js";
+
+const MAINNET: NetworkConfig = {
+  url: "https://api.fast.xyz/proxy-rest",
+  explorerUrl: "https://explorer.fast.xyz",
+  networkId: "fast:mainnet",
+  allSet: {
+    crossSignUrl: "https://cross-sign.allset.fast.xyz",
+    portalApiUrl: "https://allset.fast.xyz/api",
+    chains: {
+      ethereum: {
+        chainId: 1,
+        bridgeContract: "0xb",
+        fastBridgeAddress: "fast1b",
+        relayerUrl: "https://r/eth",
+        evmRpcUrl: "https://rpc/eth",
+        evmExplorerUrl: "https://etherscan.io",
+        tokens: {
+          USDC: {
+            evmAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            fastTokenId:
+              "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
+            decimals: 6,
+          },
+        },
+      },
+    },
+  },
+  fastTokens: {
+    fastUSD: {
+      fastTokenId:
+        "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+      decimals: 6,
+    },
+  },
+};
+
+const TESTNET: NetworkConfig = {
+  ...MAINNET,
+  fastTokens: undefined,
+  allSet: {
+    ...MAINNET.allSet!,
+    chains: {
+      "arbitrum-sepolia": {
+        ...MAINNET.allSet!.chains.ethereum!,
+        tokens: {
+          testUSDC: {
+            evmAddress: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+            fastTokenId:
+              "0xd73a0679a2be46981e2a8aedecd951c8b6690e7d5f8502b34ed3ff4cc2163b46",
+            decimals: 6,
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("selectSendTokenName (send default-token logic)", () => {
+  it("returns explicit token when provided (mainnet)", () => {
+    expect(selectSendTokenName("fastUSDC", MAINNET, undefined)).toBe("fastUSDC");
+  });
+
+  it("returns fastUSD on mainnet when token is omitted and no chain", () => {
+    expect(selectSendTokenName(undefined, MAINNET, undefined)).toBe("fastUSD");
+  });
+
+  it("returns testUSDC on testnet when token is omitted and no chain", () => {
+    expect(selectSendTokenName(undefined, TESTNET, undefined)).toBe("testUSDC");
+  });
+
+  it("returns first chain token when token is omitted and chain context exists (mainnet)", () => {
+    expect(selectSendTokenName(undefined, MAINNET, "ethereum")).toBe("USDC");
+  });
+
+  it("returns first chain token when token is omitted and chain context exists (testnet)", () => {
+    expect(selectSendTokenName(undefined, TESTNET, "arbitrum-sepolia")).toBe(
+      "testUSDC",
+    );
+  });
+
+  it("returns explicit token even when chain context is provided", () => {
+    expect(selectSendTokenName("USDT", MAINNET, "ethereum")).toBe("USDT");
+  });
+});

--- a/app/cli/tests/services/token-resolver.test.ts
+++ b/app/cli/tests/services/token-resolver.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import {
+  lookupTokenNameById,
+  resolveDefaultToken,
+  resolveToken,
+} from "../../src/services/token-resolver.js";
+import { TokenNotFoundError, UnsupportedChainError } from "../../src/errors/index.js";
+import type { NetworkConfig } from "../../src/schemas/networks.js";
+
+const MAINNET: NetworkConfig = {
+  url: "https://api.fast.xyz/proxy-rest",
+  explorerUrl: "https://explorer.fast.xyz",
+  networkId: "fast:mainnet",
+  allSet: {
+    crossSignUrl: "https://cross-sign.allset.fast.xyz",
+    portalApiUrl: "https://allset.fast.xyz/api",
+    chains: {
+      ethereum: {
+        chainId: 1,
+        bridgeContract: "0xbridge",
+        fastBridgeAddress: "fast1bridge",
+        relayerUrl: "https://relay/eth",
+        evmRpcUrl: "https://rpc/eth",
+        evmExplorerUrl: "https://etherscan.io",
+        tokens: {
+          USDC: {
+            evmAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            fastTokenId:
+              "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
+            decimals: 6,
+          },
+        },
+      },
+    },
+  },
+  fastTokens: {
+    fastUSD: {
+      fastTokenId:
+        "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+      decimals: 6,
+    },
+  },
+};
+
+const TESTNET: NetworkConfig = {
+  url: "https://testnet.api.fast.xyz/proxy-rest",
+  explorerUrl: "https://testnet.explorer.fast.xyz",
+  networkId: "fast:testnet",
+  allSet: {
+    crossSignUrl: "https://testnet.cross-sign.allset.fast.xyz",
+    portalApiUrl: "https://testnet.allset.fast.xyz/api",
+    chains: {
+      "arbitrum-sepolia": {
+        chainId: 421614,
+        bridgeContract: "0xbridge",
+        fastBridgeAddress: "fast1bridge",
+        relayerUrl: "https://relay/arb",
+        evmRpcUrl: "https://rpc/arb",
+        evmExplorerUrl: "https://sepolia.arbiscan.io",
+        tokens: {
+          testUSDC: {
+            evmAddress: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+            fastTokenId:
+              "0xd73a0679a2be46981e2a8aedecd951c8b6690e7d5f8502b34ed3ff4cc2163b46",
+            decimals: 6,
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("resolveToken", () => {
+  it("resolves a chain-scoped token (bridge route)", () => {
+    const r = resolveToken("USDC", MAINNET, "ethereum");
+    expect(r.decimals).toBe(6);
+    expect(r.evmAddress).toBe("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+  });
+
+  it("throws UnsupportedChainError for an unknown chain", () => {
+    expect(() => resolveToken("USDC", MAINNET, "polygon")).toThrow(
+      UnsupportedChainError,
+    );
+  });
+
+  it("throws TokenNotFoundError when chain exists but token does not", () => {
+    expect(() => resolveToken("WBTC", MAINNET, "ethereum")).toThrow(
+      TokenNotFoundError,
+    );
+  });
+
+  it("prefers fastTokens over chain scan when no chain context (mainnet)", () => {
+    const r = resolveToken("fastUSD", MAINNET);
+    expect(r.decimals).toBe(6);
+    expect(r.evmAddress).toBeUndefined();
+  });
+
+  it("falls back to chain scan when no fastTokens entry matches (mainnet)", () => {
+    const r = resolveToken("USDC", MAINNET);
+    expect(r.decimals).toBe(6);
+  });
+
+  it("falls back to chain scan when fastTokens is absent (testnet)", () => {
+    const r = resolveToken("testUSDC", TESTNET);
+    expect(r.decimals).toBe(6);
+  });
+
+  it("ignores fastTokens when chain context is given (mainnet)", () => {
+    expect(() => resolveToken("fastUSD", MAINNET, "ethereum")).toThrow(
+      TokenNotFoundError,
+    );
+  });
+
+  it("throws TokenNotFoundError when chain arg is given but allSet is absent", () => {
+    const cfg: NetworkConfig = { url: "x", explorerUrl: "x", networkId: "x" };
+    expect(() => resolveToken("USDC", cfg, "ethereum")).toThrow(TokenNotFoundError);
+  });
+});
+
+describe("resolveDefaultToken", () => {
+  it("returns fastUSD on mainnet", () => {
+    const r = resolveDefaultToken(MAINNET);
+    expect(r.name).toBe("fastUSD");
+    expect(r.token.decimals).toBe(6);
+  });
+
+  it("returns testUSDC on testnet (no fastTokens, falls back to first chain's first token)", () => {
+    const r = resolveDefaultToken(TESTNET);
+    expect(r.name).toBe("testUSDC");
+    expect(r.token.decimals).toBe(6);
+  });
+
+  it("throws TokenNotFoundError when nothing is registered", () => {
+    const empty: NetworkConfig = {
+      url: "x",
+      explorerUrl: "x",
+      networkId: "x",
+    };
+    expect(() => resolveDefaultToken(empty)).toThrow(TokenNotFoundError);
+  });
+
+  it("falls through to chain scan when fastTokens has multiple non-fastUSD entries", () => {
+    const cfg: NetworkConfig = {
+      url: "x",
+      explorerUrl: "x",
+      networkId: "x",
+      fastTokens: {
+        tokenA: { fastTokenId: "0xaa", decimals: 6 },
+        tokenB: { fastTokenId: "0xbb", decimals: 18 },
+      },
+      allSet: {
+        crossSignUrl: "x",
+        portalApiUrl: "x",
+        chains: {
+          someChain: {
+            chainId: 1,
+            bridgeContract: "x",
+            fastBridgeAddress: "x",
+            relayerUrl: "x",
+            evmRpcUrl: "x",
+            evmExplorerUrl: "x",
+            tokens: {
+              fallbackToken: { evmAddress: "0x1", fastTokenId: "0xcc", decimals: 8 },
+            },
+          },
+        },
+      },
+    };
+    const r = resolveDefaultToken(cfg);
+    expect(r.name).toBe("fallbackToken");
+  });
+});
+
+describe("lookupTokenNameById", () => {
+  it("returns the fastTokens key when an entry matches (mainnet)", () => {
+    const name = lookupTokenNameById(
+      MAINNET,
+      "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+    );
+    expect(name).toBe("fastUSD");
+  });
+
+  it("returns a chain-scoped token name when its fastTokenId matches", () => {
+    const name = lookupTokenNameById(
+      MAINNET,
+      "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
+    );
+    expect(name).toBe("USDC");
+  });
+
+  it("matches case-insensitively on hex value", () => {
+    const name = lookupTokenNameById(
+      MAINNET,
+      "0xC655A12330DA6AF361D281B197996D2BC135AAED3B66278E729C2222291E9130",
+    );
+    expect(name).toBe("USDC");
+  });
+
+  it("strips a leading 0x consistently on input", () => {
+    const name = lookupTokenNameById(
+      MAINNET,
+      "c655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
+    );
+    expect(name).toBe("USDC");
+  });
+
+  it("returns undefined when no entry matches", () => {
+    const name = lookupTokenNameById(MAINNET, "0xdeadbeef");
+    expect(name).toBeUndefined();
+  });
+});

--- a/app/cli/vitest.config.ts
+++ b/app/cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/docs/superpowers/plans/2026-05-06-cli-fund-restructure-and-fastusd.md
+++ b/docs/superpowers/plans/2026-05-06-cli-fund-restructure-and-fastusd.md
@@ -1,0 +1,2035 @@
+<!-- markdownlint-disable MD013 MD024 MD031 MD032 MD040 -->
+# CLI fund restructure and fastUSD adoption — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reshape the `fund` CLI command tree to `fund usdc fiat` / `fund usdc crypto` / `fund fastusd`, where `fund fastusd` emits an `app.fast.xyz/send?to=<addr>&amount=<n>` URL; make `fastUSD` (a Fast-native token, mainnet-only) the default Fast→Fast token in `send`; stop mislabeling x402 payments as `"USDC"` in display/log/history when the actual asset paid is different.
+
+**Architecture:** Optique parsers nest natively via `command()` + `or()`, so the 2-deep tree is a parser change plus updates to `main.ts`'s post-parse error helper (`SUBCOMMANDS` / `SUBCOMMAND_REQUIREMENTS`). `networks.json` gains an optional top-level `fastTokens` map per network (mainnet only); the schema gains a matching optional field; `resolveToken` learns to consult `fastTokens` first when no chain context is given, plus an inverse `lookupTokenNameById` helper used by `pay.ts` for B2-fix display/history truth. `send`'s implicit-default block delegates to a new `resolveDefaultToken` helper that prefers `fastTokens.fastUSD` on mainnet. The `fund` directory restructure is a pure file move plus a new `fastusd.ts` URL-emitter; the existing fund handlers' bodies don't change.
+
+**Tech Stack:** TypeScript, Effect, Effect Schema, `@optique/core`, vitest, Drizzle, `@fastxyz/sdk`, `@fastxyz/allset-sdk`, `@fastxyz/x402-client`.
+
+**Spec:** [docs/superpowers/specs/2026-05-06-cli-fund-restructure-and-fastusd-design.md](docs/superpowers/specs/2026-05-06-cli-fund-restructure-and-fastusd-design.md)
+
+**Branch:** `feat/cli-fund-fastusd` (off `origin/main`). Do not touch `feat/multisig-cli` (PR #85).
+
+---
+
+## File map
+
+| Status | Path | Responsibility |
+| --- | --- | --- |
+| Create | `app/cli/vitest.config.ts` | Vitest config for CLI package (matches feat/multisig-cli shape). |
+| Modify | `app/cli/package.json` | Add `"test": "vitest run"` script. |
+| Create | `app/cli/tests/services/token-resolver.test.ts` | Tests for resolver: chain-scoped, no-chain `fastTokens`, no-chain fallback, default helper, id→name helper. |
+| Create | `app/cli/tests/commands/fund-fastusd.test.ts` | URL-shape tests for `fund fastusd` (handler-level, no DB). |
+| Create | `app/cli/tests/commands/send-default-token.test.ts` | Default-token resolution for Fast→Fast `send`. |
+| Modify | `app/cli/src/schemas/networks.ts` | Add `FastTokenSchema`, optional `fastTokens` on `NetworkConfigSchema`. |
+| Modify | `app/cli/src/config/networks.json` | Add mainnet `fastTokens.fastUSD`. |
+| Modify | `app/cli/src/services/token-resolver.ts` | `fastTokens` consult; `resolveDefaultToken`; `lookupTokenNameById`. |
+| Modify | `app/cli/src/commands/send.ts` | Use `resolveDefaultToken` when `--token` is omitted. |
+| Modify | `packages/x402-client/src/types.ts` | Add `asset?: string` to `PaymentDetails`. |
+| Modify | `packages/x402-client/src/fast.ts` | Set `asset` on result; verbose log shows raw asset. |
+| Modify | `app/cli/src/commands/pay.ts` | Resolve real asset name for dry-run + history. |
+| Move + Modify | `app/cli/src/commands/fund/fiat.ts` → `app/cli/src/commands/fund/usdc/fiat.ts` | Path change + rename handler/type/discriminant; logic unchanged. |
+| Move + Modify | `app/cli/src/commands/fund/crypto.ts` → `app/cli/src/commands/fund/usdc/crypto.ts` | Path change + rename handler/type/discriminant; logic unchanged. |
+| Create | `app/cli/src/commands/fund/fastusd-url.ts` | Pure URL builder (Task 8). |
+| Create | `app/cli/src/commands/fund/fastusd.ts` | New URL-emitter handler (Task 9 step 5). |
+| Modify | `app/cli/src/cli.ts` | Restructure `fund` parser; rename arg-type exports; new `fundFastUsd` parser. |
+| Modify | `app/cli/src/commands/index.ts` | Swap imports; rename registrants. |
+| Modify | `app/cli/src/main.ts` | Update `SUBCOMMANDS["fund"]`; rekey `SUBCOMMAND_REQUIREMENTS` for 2-deep entries; add 3rd-token error message. |
+| Modify | `skills/fast/SKILL.md` | Sync command tables and walkthroughs. |
+| Modify | `app/cli/README.md` | Sync quickstart, command reference, end-to-end example. |
+| Scan | `README.md`, `SPEC.md` | Update only if stale references found. |
+
+---
+
+## Conventions for every task
+
+- Each task ends in **one** commit, conventional message style (`feat(cli): ...`, `refactor(cli): ...`, etc.).
+- Run `cd app/cli && pnpm exec tsc --noEmit` before committing each task; output must be empty. Same for `packages/x402-client` when its files change.
+- After editing any `.md` file, run `pnpm dlx markdownlint-cli --fix <file>` (per global CLAUDE.md formatting rule).
+- Do not add `--no-verify` or skip hooks.
+- One task at a time. Do not batch tasks into a single commit.
+
+---
+
+## Task 1: Vitest infrastructure for the CLI package
+
+**Files:**
+- Create: `app/cli/vitest.config.ts`
+- Modify: `app/cli/package.json`
+- Create: `app/cli/tests/sanity.test.ts` (deleted at end of this task)
+
+- [ ] **Step 1: Write the smoke test that proves vitest runs**
+
+Create `app/cli/tests/sanity.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+describe("vitest sanity", () => {
+  it("runs a trivial test", () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails (no config yet)**
+
+Run: `cd app/cli && pnpm exec vitest run`
+Expected: ERROR — vitest cannot find a config or finds no test files (depends on root-workspace vitest defaults). The exact failure mode doesn't matter; we just want to prove the test isn't already passing by accident.
+
+- [ ] **Step 3: Add the vitest config**
+
+Create `app/cli/vitest.config.ts`:
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});
+```
+
+- [ ] **Step 4: Add the `test` script to `package.json`**
+
+Edit `app/cli/package.json` `scripts` block to add `"test": "vitest run"`:
+
+```jsonc
+"scripts": {
+  "build": "tsup",
+  "prepack": "tsup",
+  "dev": "tsup --watch",
+  "test": "vitest run"
+},
+```
+
+(No new devDependency — vitest is provided by the root workspace at `/package.json`.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd app/cli && pnpm exec vitest run`
+Expected: `1 passed`. The sanity test passes.
+
+- [ ] **Step 6: Delete the sanity test**
+
+Delete `app/cli/tests/sanity.test.ts`. Real tests come in subsequent tasks.
+
+- [ ] **Step 7: Verify tsc**
+
+Run: `cd app/cli && pnpm exec tsc --noEmit`
+Expected: empty output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/cli/vitest.config.ts app/cli/package.json
+git commit -m "chore(cli): add vitest test infrastructure"
+```
+
+---
+
+## Task 2: Schema gains optional `fastTokens` field
+
+**Files:**
+- Modify: `app/cli/src/schemas/networks.ts`
+
+This is a schema-only change; no test for the schema itself (Effect Schema decoders are exercised transitively by the resolver tests in Task 3 and the bundled-config load path).
+
+- [ ] **Step 1: Add the schema**
+
+Edit `app/cli/src/schemas/networks.ts` and add the `FastTokenSchema`, plus the optional `fastTokens` field on `NetworkConfigSchema`:
+
+```ts
+import { Schema } from "effect";
+
+export const AllSetChainTokenSchema = Schema.Struct({
+  evmAddress: Schema.String,
+  fastTokenId: Schema.String,
+  decimals: Schema.Number,
+});
+export type AllSetChainTokenConfig = typeof AllSetChainTokenSchema.Type;
+
+export const AllSetChainSchema = Schema.Struct({
+  chainId: Schema.Number,
+  bridgeContract: Schema.String,
+  fastBridgeAddress: Schema.String,
+  relayerUrl: Schema.String,
+  evmRpcUrl: Schema.String,
+  evmExplorerUrl: Schema.String,
+  tokens: Schema.Record({ key: Schema.String, value: AllSetChainTokenSchema }),
+});
+export type AllSetChainConfig = typeof AllSetChainSchema.Type;
+
+export const AllSetConfigSchema = Schema.Struct({
+  crossSignUrl: Schema.String,
+  portalApiUrl: Schema.String,
+  chains: Schema.Record({ key: Schema.String, value: AllSetChainSchema }),
+});
+export type AllSetConfig = typeof AllSetConfigSchema.Type;
+
+export const FastTokenSchema = Schema.Struct({
+  fastTokenId: Schema.String,
+  decimals: Schema.Number,
+});
+export type FastTokenConfig = typeof FastTokenSchema.Type;
+
+export const NetworkConfigSchema = Schema.Struct({
+  url: Schema.String,
+  explorerUrl: Schema.String,
+  networkId: Schema.String,
+  allSet: Schema.optional(AllSetConfigSchema),
+  fastTokens: Schema.optional(
+    Schema.Record({ key: Schema.String, value: FastTokenSchema }),
+  ),
+});
+export type NetworkConfig = typeof NetworkConfigSchema.Type;
+
+export const BundledNetworksSchema = Schema.Record({
+  key: Schema.String,
+  value: NetworkConfigSchema,
+});
+export type BundledNetworks = typeof BundledNetworksSchema.Type;
+```
+
+- [ ] **Step 2: Verify tsc**
+
+Run: `cd app/cli && pnpm exec tsc --noEmit`
+Expected: empty output. (No consumer reads `fastTokens` yet, but adding optional fields breaks nothing.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/cli/src/schemas/networks.ts
+git commit -m "feat(cli): schema support for optional fastTokens map"
+```
+
+---
+
+## Task 3: Token resolver — `fastTokens` consult, default helper, inverse helper (TDD)
+
+**Files:**
+- Create: `app/cli/tests/services/token-resolver.test.ts`
+- Modify: `app/cli/src/services/token-resolver.ts`
+
+The resolver is pure (no DB / Effect services), so tests can call it synchronously with handcrafted `NetworkConfig` objects.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `app/cli/tests/services/token-resolver.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  lookupTokenNameById,
+  resolveDefaultToken,
+  resolveToken,
+} from "../../src/services/token-resolver.js";
+import { TokenNotFoundError, UnsupportedChainError } from "../../src/errors/index.js";
+import type { NetworkConfig } from "../../src/schemas/networks.js";
+
+const MAINNET: NetworkConfig = {
+  url: "https://api.fast.xyz/proxy-rest",
+  explorerUrl: "https://explorer.fast.xyz",
+  networkId: "fast:mainnet",
+  allSet: {
+    crossSignUrl: "https://cross-sign.allset.fast.xyz",
+    portalApiUrl: "https://allset.fast.xyz/api",
+    chains: {
+      ethereum: {
+        chainId: 1,
+        bridgeContract: "0xbridge",
+        fastBridgeAddress: "fast1bridge",
+        relayerUrl: "https://relay/eth",
+        evmRpcUrl: "https://rpc/eth",
+        evmExplorerUrl: "https://etherscan.io",
+        tokens: {
+          USDC: {
+            evmAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            fastTokenId:
+              "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
+            decimals: 6,
+          },
+        },
+      },
+    },
+  },
+  fastTokens: {
+    fastUSD: {
+      fastTokenId:
+        "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+      decimals: 6,
+    },
+  },
+};
+
+const TESTNET: NetworkConfig = {
+  url: "https://testnet.api.fast.xyz/proxy-rest",
+  explorerUrl: "https://testnet.explorer.fast.xyz",
+  networkId: "fast:testnet",
+  allSet: {
+    crossSignUrl: "https://testnet.cross-sign.allset.fast.xyz",
+    portalApiUrl: "https://testnet.allset.fast.xyz/api",
+    chains: {
+      "arbitrum-sepolia": {
+        chainId: 421614,
+        bridgeContract: "0xbridge",
+        fastBridgeAddress: "fast1bridge",
+        relayerUrl: "https://relay/arb",
+        evmRpcUrl: "https://rpc/arb",
+        evmExplorerUrl: "https://sepolia.arbiscan.io",
+        tokens: {
+          testUSDC: {
+            evmAddress: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+            fastTokenId:
+              "0xd73a0679a2be46981e2a8aedecd951c8b6690e7d5f8502b34ed3ff4cc2163b46",
+            decimals: 6,
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("resolveToken", () => {
+  it("resolves a chain-scoped token (bridge route)", () => {
+    const r = resolveToken("USDC", MAINNET, "ethereum");
+    expect(r.decimals).toBe(6);
+    expect(r.evmAddress).toBe("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+  });
+
+  it("throws UnsupportedChainError for an unknown chain", () => {
+    expect(() => resolveToken("USDC", MAINNET, "polygon")).toThrow(
+      UnsupportedChainError,
+    );
+  });
+
+  it("throws TokenNotFoundError when chain exists but token does not", () => {
+    expect(() => resolveToken("WBTC", MAINNET, "ethereum")).toThrow(
+      TokenNotFoundError,
+    );
+  });
+
+  it("prefers fastTokens over chain scan when no chain context (mainnet)", () => {
+    const r = resolveToken("fastUSD", MAINNET);
+    expect(r.decimals).toBe(6);
+    expect(r.evmAddress).toBeUndefined();
+  });
+
+  it("falls back to chain scan when no fastTokens entry matches (mainnet)", () => {
+    const r = resolveToken("USDC", MAINNET);
+    expect(r.decimals).toBe(6);
+  });
+
+  it("falls back to chain scan when fastTokens is absent (testnet)", () => {
+    const r = resolveToken("testUSDC", TESTNET);
+    expect(r.decimals).toBe(6);
+  });
+
+  it("ignores fastTokens when chain context is given (mainnet)", () => {
+    expect(() => resolveToken("fastUSD", MAINNET, "ethereum")).toThrow(
+      TokenNotFoundError,
+    );
+  });
+});
+
+describe("resolveDefaultToken", () => {
+  it("returns fastUSD on mainnet", () => {
+    const r = resolveDefaultToken(MAINNET);
+    expect(r.name).toBe("fastUSD");
+    expect(r.token.decimals).toBe(6);
+  });
+
+  it("returns testUSDC on testnet (no fastTokens, falls back to first chain's first token)", () => {
+    const r = resolveDefaultToken(TESTNET);
+    expect(r.name).toBe("testUSDC");
+    expect(r.token.decimals).toBe(6);
+  });
+
+  it("throws TokenNotFoundError when nothing is registered", () => {
+    const empty: NetworkConfig = {
+      url: "x",
+      explorerUrl: "x",
+      networkId: "x",
+    };
+    expect(() => resolveDefaultToken(empty)).toThrow(TokenNotFoundError);
+  });
+});
+
+describe("lookupTokenNameById", () => {
+  it("returns the fastTokens key when an entry matches (mainnet)", () => {
+    const name = lookupTokenNameById(
+      MAINNET,
+      "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+    );
+    expect(name).toBe("fastUSD");
+  });
+
+  it("returns a chain-scoped token name when its fastTokenId matches", () => {
+    const name = lookupTokenNameById(
+      MAINNET,
+      "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
+    );
+    expect(name).toBe("USDC");
+  });
+
+  it("matches case-insensitively on hex value", () => {
+    const name = lookupTokenNameById(
+      MAINNET,
+      "0xC655A12330DA6AF361D281B197996D2BC135AAED3B66278E729C2222291E9130",
+    );
+    expect(name).toBe("USDC");
+  });
+
+  it("strips a leading 0x consistently on input", () => {
+    const name = lookupTokenNameById(
+      MAINNET,
+      "c655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
+    );
+    expect(name).toBe("USDC");
+  });
+
+  it("returns undefined when no entry matches", () => {
+    const name = lookupTokenNameById(MAINNET, "0xdeadbeef");
+    expect(name).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `cd app/cli && pnpm exec vitest run tests/services/token-resolver.test.ts`
+Expected: All tests fail because `resolveDefaultToken` and `lookupTokenNameById` are not exported, and `resolveToken` does not consult `fastTokens`.
+
+- [ ] **Step 3: Update the resolver**
+
+Replace `app/cli/src/services/token-resolver.ts` with:
+
+```ts
+import { fromHex } from "@fastxyz/sdk";
+import type { NetworkConfig } from "../schemas/networks.js";
+import { TokenNotFoundError, UnsupportedChainError } from "../errors/index.js";
+
+export interface ResolvedToken {
+  readonly fastTokenId: Uint8Array;
+  readonly decimals: number;
+  readonly evmAddress?: string;
+}
+
+/**
+ * Map a token name to its on-Fast id, decimals, and (when bridging) EVM address.
+ *
+ * - With chain context (bridge route): only chain-scoped `allSet.chains[chain].tokens` is consulted.
+ * - Without chain context (Fast→Fast): `network.fastTokens` is consulted first, then chain-scoped tokens.
+ */
+export function resolveToken(
+  tokenName: string,
+  networkConfig: NetworkConfig,
+  chain?: string,
+): ResolvedToken {
+  if (chain) {
+    const allset = networkConfig.allSet;
+    if (!allset) {
+      throw new TokenNotFoundError({ token: tokenName });
+    }
+    const chainConfig = allset.chains[chain];
+    if (!chainConfig) {
+      throw new UnsupportedChainError({ chain });
+    }
+    const token = chainConfig.tokens[tokenName];
+    if (!token) {
+      throw new TokenNotFoundError({ token: tokenName });
+    }
+    return {
+      fastTokenId: fromHex(token.fastTokenId),
+      decimals: token.decimals,
+      evmAddress: token.evmAddress,
+    };
+  }
+
+  const fast = networkConfig.fastTokens?.[tokenName];
+  if (fast) {
+    return {
+      fastTokenId: fromHex(fast.fastTokenId),
+      decimals: fast.decimals,
+    };
+  }
+
+  const allset = networkConfig.allSet;
+  if (allset) {
+    for (const chainConfig of Object.values(allset.chains)) {
+      const token = chainConfig.tokens[tokenName];
+      if (token) {
+        return {
+          fastTokenId: fromHex(token.fastTokenId),
+          decimals: token.decimals,
+        };
+      }
+    }
+  }
+
+  throw new TokenNotFoundError({ token: tokenName });
+}
+
+/**
+ * Resolve the implicit default token for a Fast→Fast operation.
+ * Prefers `fastTokens.fastUSD`, then any single `fastTokens` entry,
+ * then the first chain's first token. Throws TokenNotFoundError if none.
+ */
+export function resolveDefaultToken(networkConfig: NetworkConfig): {
+  readonly name: string;
+  readonly token: ResolvedToken;
+} {
+  const fast = networkConfig.fastTokens;
+  if (fast) {
+    if ("fastUSD" in fast) {
+      const t = fast.fastUSD!;
+      return {
+        name: "fastUSD",
+        token: { fastTokenId: fromHex(t.fastTokenId), decimals: t.decimals },
+      };
+    }
+    const keys = Object.keys(fast);
+    if (keys.length === 1) {
+      const name = keys[0]!;
+      const t = fast[name]!;
+      return {
+        name,
+        token: { fastTokenId: fromHex(t.fastTokenId), decimals: t.decimals },
+      };
+    }
+    // Multiple entries, none called "fastUSD" — ambiguous, fall through.
+  }
+
+  const allset = networkConfig.allSet;
+  if (allset) {
+    const firstChain = Object.values(allset.chains)[0];
+    if (firstChain) {
+      const firstName = Object.keys(firstChain.tokens)[0];
+      if (firstName) {
+        const token = firstChain.tokens[firstName]!;
+        return {
+          name: firstName,
+          token: {
+            fastTokenId: fromHex(token.fastTokenId),
+            decimals: token.decimals,
+          },
+        };
+      }
+    }
+  }
+
+  throw new TokenNotFoundError({ token: "<default>" });
+}
+
+/** Normalise a hex string for comparison: strip leading 0x and lowercase. */
+const norm = (h: string): string =>
+  (h.startsWith("0x") || h.startsWith("0X") ? h.slice(2) : h).toLowerCase();
+
+/**
+ * Inverse of resolveToken: given a fastTokenId hex (server's payment requirement),
+ * return the registered display name. Searches `fastTokens` then `allSet.chains[*].tokens`.
+ * Returns undefined when no entry matches.
+ */
+export function lookupTokenNameById(
+  networkConfig: NetworkConfig,
+  fastTokenId: string,
+): string | undefined {
+  const target = norm(fastTokenId);
+
+  const fast = networkConfig.fastTokens;
+  if (fast) {
+    for (const [name, entry] of Object.entries(fast)) {
+      if (norm(entry.fastTokenId) === target) return name;
+    }
+  }
+
+  const allset = networkConfig.allSet;
+  if (allset) {
+    for (const chain of Object.values(allset.chains)) {
+      for (const [name, entry] of Object.entries(chain.tokens)) {
+        if (norm(entry.fastTokenId) === target) return name;
+      }
+    }
+  }
+
+  return undefined;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd app/cli && pnpm exec vitest run tests/services/token-resolver.test.ts`
+Expected: All resolver tests pass.
+
+- [ ] **Step 5: Verify tsc**
+
+Run: `cd app/cli && pnpm exec tsc --noEmit`
+Expected: empty output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/cli/src/services/token-resolver.ts app/cli/tests/services/token-resolver.test.ts
+git commit -m "feat(cli): token resolver consults fastTokens + add default and id->name helpers"
+```
+
+---
+
+## Task 4: Register `fastUSD` in `networks.json` (mainnet)
+
+**Files:**
+- Modify: `app/cli/src/config/networks.json`
+
+The schema gained the field in Task 2; the resolver gained the lookup logic in Task 3; this task wires the actual data so the bundled mainnet config has fastUSD available.
+
+- [ ] **Step 1: Add the data**
+
+Edit `app/cli/src/config/networks.json`. Inside the `mainnet` object, after the `allSet` block, add:
+
+```json
+"fastTokens": {
+  "fastUSD": {
+    "fastTokenId": "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+    "decimals": 6
+  }
+}
+```
+
+The `mainnet` object then ends:
+
+```json
+"mainnet": {
+  "url": "...",
+  "explorerUrl": "...",
+  "networkId": "fast:mainnet",
+  "allSet": { ... },
+  "fastTokens": {
+    "fastUSD": {
+      "fastTokenId": "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+      "decimals": 6
+    }
+  }
+}
+```
+
+Do NOT add `fastTokens` to the `testnet` block — testnet has no fastUSD.
+
+- [ ] **Step 2: Verify the schema accepts it**
+
+Run: `cd app/cli && pnpm exec tsc --noEmit`
+Expected: empty output (the JSON is loaded as a module via `tsconfig`'s `resolveJsonModule`; the schema decode happens at runtime in `services/config/app.ts`, but tsc still validates the type shape).
+
+- [ ] **Step 3: Run all CLI tests so far**
+
+Run: `cd app/cli && pnpm exec vitest run`
+Expected: all tests pass (no behavior change — resolver tests use handcrafted configs, and no other consumer reads `fastTokens` yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/cli/src/config/networks.json
+git commit -m "feat(cli): register fastUSD in mainnet bundled network config"
+```
+
+---
+
+## Task 5: `send` Fast→Fast uses `resolveDefaultToken` (TDD)
+
+**Files:**
+- Create: `app/cli/tests/commands/send-default-token.test.ts`
+- Modify: `app/cli/src/commands/send.ts`
+
+The test exercises only the implicit-default selection logic — not the entire send handler. Specifically: today, when `args.token` is undefined, `send.ts` constructs `resolvedTokenName` via an inline IIFE that scans the first chain. This IIFE must be replaced with a call to `resolveDefaultToken`. To test this without spinning up an entire Effect runtime + DB, we test `resolveDefaultToken` directly (Task 3 covered that) and add a focused integration-ish test that spies on the IIFE replacement via re-export.
+
+For the focused command-level test we exercise the small piece of logic that belongs to `send.ts`: the `resolvedTokenName` selection block. We extract it into a tiny helper so it's testable without an Effect runtime.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/cli/tests/commands/send-default-token.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { selectSendTokenName } from "../../src/commands/send-token-helper.js";
+import type { NetworkConfig } from "../../src/schemas/networks.js";
+
+const MAINNET: NetworkConfig = {
+  url: "https://api.fast.xyz/proxy-rest",
+  explorerUrl: "https://explorer.fast.xyz",
+  networkId: "fast:mainnet",
+  allSet: {
+    crossSignUrl: "https://cross-sign.allset.fast.xyz",
+    portalApiUrl: "https://allset.fast.xyz/api",
+    chains: {
+      ethereum: {
+        chainId: 1,
+        bridgeContract: "0xb",
+        fastBridgeAddress: "fast1b",
+        relayerUrl: "https://r/eth",
+        evmRpcUrl: "https://rpc/eth",
+        evmExplorerUrl: "https://etherscan.io",
+        tokens: {
+          USDC: {
+            evmAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            fastTokenId:
+              "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
+            decimals: 6,
+          },
+        },
+      },
+    },
+  },
+  fastTokens: {
+    fastUSD: {
+      fastTokenId:
+        "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+      decimals: 6,
+    },
+  },
+};
+
+const TESTNET: NetworkConfig = {
+  ...MAINNET,
+  fastTokens: undefined,
+  allSet: {
+    ...MAINNET.allSet!,
+    chains: {
+      "arbitrum-sepolia": {
+        ...MAINNET.allSet!.chains.ethereum!,
+        tokens: {
+          testUSDC: {
+            evmAddress: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+            fastTokenId:
+              "0xd73a0679a2be46981e2a8aedecd951c8b6690e7d5f8502b34ed3ff4cc2163b46",
+            decimals: 6,
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("selectSendTokenName (send default-token logic)", () => {
+  it("returns explicit token when provided (mainnet)", () => {
+    expect(selectSendTokenName("fastUSDC", MAINNET, undefined)).toBe("fastUSDC");
+  });
+
+  it("returns fastUSD on mainnet when token is omitted and no chain", () => {
+    expect(selectSendTokenName(undefined, MAINNET, undefined)).toBe("fastUSD");
+  });
+
+  it("returns testUSDC on testnet when token is omitted and no chain", () => {
+    expect(selectSendTokenName(undefined, TESTNET, undefined)).toBe("testUSDC");
+  });
+
+  it("returns first chain token when token is omitted and chain context exists (mainnet)", () => {
+    expect(selectSendTokenName(undefined, MAINNET, "ethereum")).toBe("USDC");
+  });
+
+  it("returns first chain token when token is omitted and chain context exists (testnet)", () => {
+    expect(selectSendTokenName(undefined, TESTNET, "arbitrum-sepolia")).toBe(
+      "testUSDC",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd app/cli && pnpm exec vitest run tests/commands/send-default-token.test.ts`
+Expected: FAIL — module `../../src/commands/send-token-helper.js` not found.
+
+- [ ] **Step 3: Extract the helper**
+
+Create `app/cli/src/commands/send-token-helper.ts`:
+
+```ts
+import type { NetworkConfig } from "../schemas/networks.js";
+import { resolveDefaultToken } from "../services/token-resolver.js";
+
+/**
+ * Pick the token NAME (a string the resolver later maps to a ResolvedToken) for
+ * a `send` invocation given the user's --token flag and bridge chain context.
+ *
+ * - Explicit --token wins.
+ * - With chain context (--from-chain / --to-chain): default to first token on that
+ *   chain, falling back to "USDC" only if the chain config is somehow empty.
+ * - Without chain context (Fast→Fast): use resolveDefaultToken (prefers fastTokens.fastUSD on mainnet).
+ */
+export function selectSendTokenName(
+  explicit: string | undefined,
+  networkConfig: NetworkConfig,
+  chain: string | undefined,
+): string {
+  if (explicit !== undefined) return explicit;
+
+  if (chain) {
+    const chainCfg = networkConfig.allSet?.chains[chain];
+    const first = chainCfg ? Object.keys(chainCfg.tokens)[0] : undefined;
+    return first ?? "USDC";
+  }
+
+  return resolveDefaultToken(networkConfig).name;
+}
+```
+
+- [ ] **Step 4: Wire the helper into `send.ts`**
+
+In `app/cli/src/commands/send.ts`, replace the inline default-token IIFE (current lines 122-131) with a call to the helper.
+
+Today:
+
+```ts
+const tokenChain = fromChain ?? toChain;
+const resolvedTokenName =
+  args.token ??
+  (() => {
+    const chains = network.allSet?.chains ?? {};
+    const firstChain = Object.values(chains)[0];
+    return firstChain
+      ? (Object.keys(firstChain.tokens)[0] ?? "USDC")
+      : "USDC";
+  })();
+```
+
+New:
+
+```ts
+const tokenChain = fromChain ?? toChain;
+const resolvedTokenName = selectSendTokenName(args.token, network, tokenChain);
+```
+
+Add the import at the top of `send.ts`:
+
+```ts
+import { selectSendTokenName } from "./send-token-helper.js";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd app/cli && pnpm exec vitest run tests/commands/send-default-token.test.ts`
+Expected: all 5 tests pass.
+
+- [ ] **Step 6: Run all CLI tests**
+
+Run: `cd app/cli && pnpm exec vitest run`
+Expected: all tests pass.
+
+- [ ] **Step 7: Verify tsc**
+
+Run: `cd app/cli && pnpm exec tsc --noEmit`
+Expected: empty output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/cli/src/commands/send-token-helper.ts app/cli/src/commands/send.ts app/cli/tests/commands/send-default-token.test.ts
+git commit -m "feat(cli): send Fast->Fast defaults to fastUSD on mainnet"
+```
+
+---
+
+## Task 6: x402-client surfaces `asset` on `PaymentDetails`
+
+**Files:**
+- Modify: `packages/x402-client/src/types.ts`
+- Modify: `packages/x402-client/src/fast.ts`
+
+The x402-client has a vitest setup of its own (`packages/x402-client/tests/`); we add a tiny focused test for the new `asset` field on the result.
+
+- [ ] **Step 1: Write the failing test**
+
+Edit `packages/x402-client/tests/index.test.ts` and add a new `describe` block at the bottom (inside the outer `describe('x402-client', ...)`):
+
+```ts
+  describe('PaymentDetails.asset', () => {
+    it('exposes the asset hex on the result so callers can label payments correctly', async () => {
+      // This is a structural assertion — it confirms the type carries `asset`
+      // and that fast.ts populates it from the server's payment requirement.
+      // We do NOT exercise the full Fast network flow (that's covered
+      // by integration tests). We do a minimal handler-level check by
+      // constructing a result via the public type and verifying TS accepts it.
+      const sample: import('../src/types.js').PaymentDetails = {
+        network: 'fast-mainnet',
+        amount: '1.0',
+        recipient: 'fast1abc',
+        txHash: '0xdead',
+        asset:
+          '0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb',
+      };
+      expect(sample.asset).toBe(
+        '0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb',
+      );
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/x402-client && pnpm exec vitest run tests/index.test.ts`
+Expected: FAIL — TypeScript error "Object literal may only specify known properties, and `asset` does not exist in type `PaymentDetails`."
+
+- [ ] **Step 3: Extend `PaymentDetails`**
+
+Edit `packages/x402-client/src/types.ts` line 108-115 (the `PaymentDetails` interface). Add an optional `asset` field:
+
+```ts
+/**
+ * Payment details in response
+ */
+export interface PaymentDetails {
+  network: string;
+  amount: string;
+  recipient: string;
+  txHash: string;
+  /** The token id (hex string) actually paid, mirrored from the server's payment requirement. */
+  asset?: string;
+  bridged?: boolean;
+  bridgeTxHash?: string;
+}
+```
+
+- [ ] **Step 4: Populate `asset` in `fast.ts`**
+
+Edit `packages/x402-client/src/fast.ts` lines 205-220 (the return statement of `handleFastPayment`). Add `asset` to the `payment` object:
+
+```ts
+return {
+  success: paidRes.ok,
+  statusCode: paidRes.status,
+  headers: resHeaders,
+  body: resBody,
+  payment: {
+    network: fastReq.network,
+    amount: amountHuman,
+    recipient: fastReq.payTo,
+    txHash,
+    asset: fastReq.asset,
+  },
+  note: paidRes.ok
+    ? `Fast payment of ${amountHuman} successful. Content delivered.`
+    : `Payment submitted (tx: ${txHash}) but server returned ${paidRes.status}.`,
+  logs: verbose ? logs : undefined,
+};
+```
+
+- [ ] **Step 5: Fix the verbose log line**
+
+In the same `fast.ts`, replace line 137 (the misleading `→ ${amountHuman} USDC` log):
+
+Old:
+
+```ts
+log(`  Amount: ${fastReq.maxAmountRequired} raw → ${amountHuman} USDC`);
+```
+
+New:
+
+```ts
+log(`  Amount: ${fastReq.maxAmountRequired} raw → ${amountHuman} (asset ${fastReq.asset})`);
+```
+
+- [ ] **Step 6: Run the x402-client tests**
+
+Run: `cd packages/x402-client && pnpm exec vitest run`
+Expected: all tests pass.
+
+- [ ] **Step 7: Verify tsc**
+
+Run: `cd packages/x402-client && pnpm exec tsc --noEmit`
+Expected: empty output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/x402-client/src/types.ts packages/x402-client/src/fast.ts packages/x402-client/tests/index.test.ts
+git commit -m "feat(x402-client): surface asset on PaymentDetails; fix misleading USDC log"
+```
+
+---
+
+## Task 7: `pay.ts` resolves real asset name for dry-run + history (TDD)
+
+**Files:**
+- Modify: `app/cli/src/commands/pay.ts`
+
+`pay.ts` integrates many services so a full handler test is heavy. We instead:
+
+1. Use `lookupTokenNameById` (Task 3) inside `pay.ts` to resolve names.
+2. Add a focused unit test that constructs a fake history-entry object using the same helper, demonstrating that the helper produces the right name and "unknown" fallback. This is sufficient to exercise the code path without spinning up the full handler.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new test file `app/cli/tests/commands/pay-asset-label.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { labelAssetForPayment } from "../../src/commands/pay-asset-label.js";
+import type { NetworkConfig } from "../../src/schemas/networks.js";
+
+const MAINNET: NetworkConfig = {
+  url: "https://api.fast.xyz/proxy-rest",
+  explorerUrl: "https://explorer.fast.xyz",
+  networkId: "fast:mainnet",
+  fastTokens: {
+    fastUSD: {
+      fastTokenId:
+        "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+      decimals: 6,
+    },
+  },
+};
+
+describe("labelAssetForPayment", () => {
+  it("returns the registered token name when asset matches", () => {
+    expect(
+      labelAssetForPayment(
+        MAINNET,
+        "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+      ),
+    ).toBe("fastUSD");
+  });
+
+  it("returns 'unknown' when asset is undefined", () => {
+    expect(labelAssetForPayment(MAINNET, undefined)).toBe("unknown");
+  });
+
+  it("returns the short hex when asset is unknown", () => {
+    expect(labelAssetForPayment(MAINNET, "0xdeadbeefcafe1234")).toBe(
+      "0xdeadbeefcafe1234",
+    );
+  });
+
+  it("returns the empty-string fallback as 'unknown'", () => {
+    expect(labelAssetForPayment(MAINNET, "")).toBe("unknown");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd app/cli && pnpm exec vitest run tests/commands/pay-asset-label.test.ts`
+Expected: FAIL — module `../../src/commands/pay-asset-label.js` not found.
+
+- [ ] **Step 3: Add the helper**
+
+Create `app/cli/src/commands/pay-asset-label.ts`:
+
+```ts
+import type { NetworkConfig } from "../schemas/networks.js";
+import { lookupTokenNameById } from "../services/token-resolver.js";
+
+/**
+ * Translate a server-supplied asset hex into a display string for the pay
+ * dry-run printer and the history entry's `tokenName` column.
+ *
+ * - undefined / "" → "unknown"
+ * - registered → the registry's display name (e.g. "fastUSD", "USDC")
+ * - unregistered hex → the hex itself (so callers can still trace it on-chain)
+ */
+export function labelAssetForPayment(
+  networkConfig: NetworkConfig,
+  asset: string | undefined,
+): string {
+  if (!asset) return "unknown";
+  const name = lookupTokenNameById(networkConfig, asset);
+  return name ?? asset;
+}
+```
+
+- [ ] **Step 4: Wire the helper into `pay.ts`**
+
+Edit `app/cli/src/commands/pay.ts`. Three substitutions; explicit before/after each.
+
+**Note on a small semantic change in this step:** today the network is resolved at line 106, *after* the dry-run early return. To make the dry-run display use real asset names, this step **hoists** the `network` resolution above the dry-run branch. After the change, dry-run mode also resolves the active network — so a broken network config will fail dry-run, where today it would not. This is a deliberate, low-cost change (one extra DB read on dry-run) and arguably better behavior; mention it in the commit message.
+
+(a) **Imports** — add the helper and the `NetworkConfigService` is already imported. Add at the top:
+
+```ts
+import { labelAssetForPayment } from "./pay-asset-label.js";
+```
+
+(b) **Dry-run display** (current line 94). The dry-run path resolves the network via `networkConfig.resolve(config.network)` later in normal mode, but the dry-run path runs *before* network resolution. Restructure so the network is resolved up-front and made available to both branches. Add right after the `body` line (around line 56):
+
+```ts
+const network = yield* networkConfig.resolve(config.network);
+```
+
+Then in the dry-run loop (around line 90-95), replace:
+
+```ts
+yield* output.humanLine(`  Asset:   ${opt.asset ?? "USDC"}`);
+```
+
+With:
+
+```ts
+yield* output.humanLine(
+  `  Asset:   ${labelAssetForPayment(network, opt.asset)}`,
+);
+```
+
+Then **remove** the duplicate `const network = yield* networkConfig.resolve(config.network);` line that previously appeared in the normal-mode branch (around line 106) — it's now hoisted above.
+
+(c) **History entry tokenName** (current line 191). Replace:
+
+```ts
+tokenName: "USDC",
+```
+
+With:
+
+```ts
+tokenName: labelAssetForPayment(network, p.asset),
+```
+
+The `result.payment.asset` field exists from Task 6.
+
+- [ ] **Step 5: Run the new test to verify it passes**
+
+Run: `cd app/cli && pnpm exec vitest run tests/commands/pay-asset-label.test.ts`
+Expected: all 4 tests pass.
+
+- [ ] **Step 6: Run all CLI tests**
+
+Run: `cd app/cli && pnpm exec vitest run`
+Expected: all tests pass.
+
+- [ ] **Step 7: Verify tsc**
+
+Run: `cd app/cli && pnpm exec tsc --noEmit`
+Expected: empty output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/cli/src/commands/pay-asset-label.ts app/cli/src/commands/pay.ts app/cli/tests/commands/pay-asset-label.test.ts
+git commit -m "fix(cli): pay shows real asset name in dry-run and history"
+```
+
+---
+
+## Task 8: `fund fastusd` URL builder helper (TDD, pure)
+
+**Files:**
+- Create: `app/cli/src/commands/fund/fastusd-url.ts` (pure URL builder)
+- Create: `app/cli/tests/commands/fund-fastusd.test.ts` (URL builder tests)
+
+The handler that uses this helper is created in Task 9 (so `cli.ts` parser additions, the new arg type, and the handler all land together with `tsc` clean). This task lands the pure URL builder + its tests independently.
+
+**Tests are limited to the URL builder.** Handler-level tests (mainnet-only check, `--to` default to active account, address validation, JSON output shape) would require setting up an Effect runtime with a mocked `AccountStore` / `Output` / `ClientConfig` — and there is no such test scaffolding for any other CLI handler on `origin/main`. Introducing it for one new handler is out of scope; manual smoke testing in Task 11 step 4 verifies the handler paths instead.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/cli/tests/commands/fund-fastusd.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildFundFastUsdUrl } from "../../src/commands/fund/fastusd-url.js";
+
+describe("buildFundFastUsdUrl", () => {
+  it("emits to= when only address is provided", () => {
+    expect(buildFundFastUsdUrl("fast1abc", undefined)).toBe(
+      "https://app.fast.xyz/send?to=fast1abc",
+    );
+  });
+
+  it("emits both to= and amount= when both are provided", () => {
+    expect(buildFundFastUsdUrl("fast1abc", "10")).toBe(
+      "https://app.fast.xyz/send?to=fast1abc&amount=10",
+    );
+  });
+
+  it("preserves a decimal amount unchanged", () => {
+    expect(buildFundFastUsdUrl("fast1abc", "10.5")).toBe(
+      "https://app.fast.xyz/send?to=fast1abc&amount=10.5",
+    );
+  });
+
+  it("URL-encodes special characters in the address", () => {
+    expect(buildFundFastUsdUrl("fast1abc def", "10")).toBe(
+      "https://app.fast.xyz/send?to=fast1abc+def&amount=10",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd app/cli && pnpm exec vitest run tests/commands/fund-fastusd.test.ts`
+Expected: FAIL — module `../../src/commands/fund/fastusd-url.js` not found.
+
+- [ ] **Step 3: Write the URL builder**
+
+Create `app/cli/src/commands/fund/fastusd-url.ts`:
+
+```ts
+const APP_BASE = "https://app.fast.xyz/send";
+
+/**
+ * Build the `app.fast.xyz/send` URL that opens the unified Fast funding flow.
+ * The web app accepts both query params as optional and prompts the user when missing.
+ */
+export function buildFundFastUsdUrl(
+  to: string,
+  amount: string | undefined,
+): string {
+  const params = new URLSearchParams({ to });
+  if (amount !== undefined) {
+    params.set("amount", amount);
+  }
+  return `${APP_BASE}?${params.toString()}`;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd app/cli && pnpm exec vitest run tests/commands/fund-fastusd.test.ts`
+Expected: 4 passed.
+
+- [ ] **Step 5: Verify tsc**
+
+Run: `cd app/cli && pnpm exec tsc --noEmit`
+Expected: empty output. (The URL builder is self-contained — no dependency on types that arrive in Task 9.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/cli/src/commands/fund/fastusd-url.ts app/cli/tests/commands/fund-fastusd.test.ts
+git commit -m "feat(cli): fund fastusd URL builder helper"
+```
+
+---
+
+## Task 9: Restructure `fund` command tree — parsers, registry, dispatch
+
+**Files:**
+- Modify: `app/cli/src/cli.ts`
+- Modify: `app/cli/src/commands/index.ts`
+- Modify: `app/cli/src/main.ts`
+- Move: `app/cli/src/commands/fund/fiat.ts` → `app/cli/src/commands/fund/usdc/fiat.ts`
+- Move: `app/cli/src/commands/fund/crypto.ts` → `app/cli/src/commands/fund/usdc/crypto.ts`
+
+This is the biggest single change. We do it in one task because the parser, registry, and main dispatch are tightly coupled — partial changes leave the build broken.
+
+- [ ] **Step 1: Move the `fiat.ts` and `crypto.ts` files into the new `usdc/` subdirectory**
+
+```bash
+mkdir -p app/cli/src/commands/fund/usdc
+git mv app/cli/src/commands/fund/fiat.ts app/cli/src/commands/fund/usdc/fiat.ts
+git mv app/cli/src/commands/fund/crypto.ts app/cli/src/commands/fund/usdc/crypto.ts
+```
+
+- [ ] **Step 2: Update import depths inside the moved files**
+
+In both `app/cli/src/commands/fund/usdc/fiat.ts` and `app/cli/src/commands/fund/usdc/crypto.ts`, every relative import currently reads `../../...`. They now need one more `../`. Update each file's imports.
+
+For `fiat.ts`, the imports change from `../../cli.js`, `../../errors/index.js`, etc. to `../../../cli.js`, `../../../errors/index.js`, etc. **Concrete diff for `fiat.ts`:**
+
+Old top of file:
+
+```ts
+import { Effect } from "effect";
+import type { FundFiatArgs } from "../../cli.js";
+import { InvalidAddressError, InvalidUsageError } from "../../errors/index.js";
+import { ClientConfig } from "../../services/config/client.js";
+import { Output } from "../../services/output.js";
+import { AccountStore } from "../../services/storage/account.js";
+import type { Command } from "../index.js";
+```
+
+New top of file:
+
+```ts
+import { Effect } from "effect";
+import type { FundUsdcFiatArgs } from "../../../cli.js";
+import { InvalidAddressError, InvalidUsageError } from "../../../errors/index.js";
+import { ClientConfig } from "../../../services/config/client.js";
+import { Output } from "../../../services/output.js";
+import { AccountStore } from "../../../services/storage/account.js";
+import type { Command } from "../../index.js";
+```
+
+Then change the exported handler name and discriminant:
+
+Old:
+
+```ts
+export const fundFiat: Command<FundFiatArgs> = {
+  cmd: "fund-fiat",
+```
+
+New:
+
+```ts
+export const fundUsdcFiat: Command<FundUsdcFiatArgs> = {
+  cmd: "fund-usdc-fiat",
+```
+
+Repeat the analogous changes in `crypto.ts`:
+- Type rename: `FundCryptoArgs` → `FundUsdcCryptoArgs`.
+- Handler rename: `fundCrypto` → `fundUsdcCrypto`.
+- Discriminant rename: `"fund-crypto"` → `"fund-usdc-crypto"`.
+- Three-deep relative imports.
+
+- [ ] **Step 3: Restructure parsers in `cli.ts`**
+
+Edit `app/cli/src/cli.ts`. Find the `// Fund commands` section (currently lines 351-396) and replace **the entire fund block** (the three parsers `fundFiatParser`, `fundCryptoParser`, `fundGroup`) with:
+
+```ts
+// ---------------------------------------------------------------------------
+// Fund commands
+// ---------------------------------------------------------------------------
+
+const fundUsdcFiatParser = command(
+  "fiat",
+  object({
+    cmd: constant("fund-usdc-fiat" as const),
+    address: optional(
+      option("--address", string({ metavar: "ADDRESS" }), {
+        description: message`Fast address to fund (default: default account)`,
+      }),
+    ),
+  }),
+  { description: message`Get a fiat on-ramp funding URL (USDC via Ramp)` },
+);
+
+const fundUsdcCryptoParser = command(
+  "crypto",
+  object({
+    cmd: constant("fund-usdc-crypto" as const),
+    amount: argument(string({ metavar: "AMOUNT" }), {
+      description: message`Human-readable amount to fund (e.g., 100.00)`,
+    }),
+    chain: option("--chain", string({ metavar: "CHAIN" }), {
+      description: message`EVM chain to bridge from (see fast info bridge-chains)`,
+    }),
+    token: optional(
+      option("--token", string({ metavar: "TOKEN" }), {
+        description: message`Token to bridge (default: USDC / testUSDC)`,
+      }),
+    ),
+    eip7702: withDefault(
+      option("--eip-7702", {
+        description: message`Use EIP-7702 smart deposit (gas paid in USDC via paymaster, no ETH required)`,
+      }),
+      false,
+    ),
+  }),
+  { description: message`Bridge USDC from an EVM chain (lands as fastUSDC)` },
+);
+
+const fundUsdcGroup = command(
+  "usdc",
+  or(fundUsdcFiatParser, fundUsdcCryptoParser),
+  { description: message`Fund with USDC (lands as fastUSDC on Fast)` },
+);
+
+const fundFastUsdParser = command(
+  "fastusd",
+  object({
+    cmd: constant("fund-fastusd" as const),
+    to: optional(
+      option("--to", string({ metavar: "ADDRESS" }), {
+        description: message`Fast address to fund (default: default account)`,
+      }),
+    ),
+    amount: optional(
+      option("--amount", string({ metavar: "AMOUNT" }), {
+        description: message`Optional amount (decimal, e.g. 10.5)`,
+      }),
+    ),
+  }),
+  {
+    description: message`Print a Fast web-app URL to fund your account with fastUSD (mainnet only)`,
+  },
+);
+
+const fundGroup = command(
+  "fund",
+  or(fundUsdcGroup, fundFastUsdParser),
+  { description: message`Fund your account` },
+);
+```
+
+- [ ] **Step 4: Restructure exported types in `cli.ts`**
+
+Still in `cli.ts`. Find the export block (currently lines 471-473):
+
+```ts
+export type FundFiatArgs = InferValue<typeof fundFiatParser>;
+export type FundCryptoArgs = InferValue<typeof fundCryptoParser>;
+export type PayArgs = InferValue<typeof payParser>;
+```
+
+Replace with:
+
+```ts
+export type FundUsdcFiatArgs = InferValue<typeof fundUsdcFiatParser>;
+export type FundUsdcCryptoArgs = InferValue<typeof fundUsdcCryptoParser>;
+export type FundFastUsdArgs = InferValue<typeof fundFastUsdParser>;
+export type PayArgs = InferValue<typeof payParser>;
+```
+
+The root-union line `const commands = or(accountGroup, networkGroup, infoGroup, sendParser, fundGroup, payParser);` is unchanged (`fundGroup` is now the new tree).
+
+- [ ] **Step 5: Create the `fund fastusd` handler**
+
+Create `app/cli/src/commands/fund/fastusd.ts`:
+
+```ts
+import { Effect } from "effect";
+import type { FundFastUsdArgs } from "../../cli.js";
+import { InvalidAddressError, InvalidAmountError, InvalidUsageError } from "../../errors/index.js";
+import { ClientConfig } from "../../services/config/client.js";
+import { Output } from "../../services/output.js";
+import { AccountStore } from "../../services/storage/account.js";
+import type { Command } from "../index.js";
+import { buildFundFastUsdUrl } from "./fastusd-url.js";
+
+const isPositiveDecimal = (s: string): boolean => {
+  if (s.trim() === "") return false;
+  if (!/^\d+(\.\d+)?$/.test(s)) return false;
+  return Number.parseFloat(s) > 0;
+};
+
+export const fundFastUsd: Command<FundFastUsdArgs> = {
+  cmd: "fund-fastusd",
+  handler: (args) =>
+    Effect.gen(function* () {
+      const accounts = yield* AccountStore;
+      const output = yield* Output;
+      const config = yield* ClientConfig;
+
+      if (config.network !== "mainnet") {
+        return yield* Effect.fail(
+          new InvalidUsageError({
+            message:
+              `fastUSD funding is only available on mainnet. ` +
+              `Current network: ${config.network}. ` +
+              `Switch with --network mainnet.`,
+          }),
+        );
+      }
+
+      let address: string;
+      if (args.to) {
+        if (!args.to.startsWith("fast1")) {
+          return yield* Effect.fail(
+            new InvalidAddressError({
+              message: `Invalid Fast address "${args.to}". Must start with fast1.`,
+            }),
+          );
+        }
+        address = args.to;
+      } else {
+        const account = yield* accounts.resolveAccount(config.account);
+        address = account.fastAddress;
+      }
+
+      if (args.amount !== undefined && !isPositiveDecimal(args.amount)) {
+        return yield* Effect.fail(
+          new InvalidAmountError({
+            message: `Invalid amount "${args.amount}". Expected a positive decimal (e.g. 10 or 1.5).`,
+          }),
+        );
+      }
+
+      const url = buildFundFastUsdUrl(address, args.amount);
+
+      yield* output.humanLine("Open this URL in your browser to fund your account:");
+      yield* output.humanLine("");
+      yield* output.humanLine(`  ${url}`);
+      yield* output.humanLine("");
+      yield* output.ok({ url, address });
+    }),
+};
+```
+
+This file depends on `FundFastUsdArgs` (added in Step 4) and `buildFundFastUsdUrl` (added in Task 8). Both are present at this point.
+
+- [ ] **Step 6: Update the command registry in `commands/index.ts`**
+
+Edit `app/cli/src/commands/index.ts`. Replace the two fund imports:
+
+Old:
+
+```ts
+import { fundCrypto } from "./fund/crypto.js";
+import { fundFiat } from "./fund/fiat.js";
+```
+
+New:
+
+```ts
+import { fundFastUsd } from "./fund/fastusd.js";
+import { fundUsdcCrypto } from "./fund/usdc/crypto.js";
+import { fundUsdcFiat } from "./fund/usdc/fiat.js";
+```
+
+Replace the registrations in the `commands` array:
+
+Old:
+
+```ts
+fundCrypto,
+fundFiat,
+```
+
+New (alphabetised to match surrounding style):
+
+```ts
+fundFastUsd,
+fundUsdcCrypto,
+fundUsdcFiat,
+```
+
+- [ ] **Step 7: Update dispatch metadata in `main.ts`**
+
+Edit `app/cli/src/main.ts`.
+
+(a) `SUBCOMMANDS["fund"]` (current line 157):
+
+Old:
+
+```ts
+fund: ["fiat", "crypto"],
+```
+
+New:
+
+```ts
+fund: ["usdc", "fastusd"],
+```
+
+(b) `SUBCOMMAND_REQUIREMENTS` (currently lines 222-237). Remove the two old fund entries:
+
+Old:
+
+```ts
+"fund crypto": {
+  usage: "fast fund crypto <amount> --chain <chain> [--token <token>]",
+  options: ["--chain", "--token", "--eip-7702"],
+  check: (positionals, allArgv) => {
+    if (positionals.length < 3) return "Missing required argument: <amount>";
+    if (!allArgv.some((a) => a === "--chain" || a.startsWith("--chain=")))
+      return "Missing required option: --chain <chain>";
+    return null;
+  },
+},
+"fund fiat": {
+  usage: "fast fund fiat [--address <address>]",
+  options: ["--address"],
+  check: () => null,
+},
+```
+
+Replace with:
+
+```ts
+"fund usdc": {
+  usage: "fast fund usdc <fiat|crypto>",
+  options: [],
+  check: (positionals) => {
+    const third = positionals[2];
+    if (!third) return "Missing subcommand. Available: fiat, crypto";
+    if (third !== "fiat" && third !== "crypto")
+      return `Unknown subcommand '${third}' for 'fund usdc'. Available: fiat, crypto`;
+    return null;
+  },
+},
+"fund usdc fiat": {
+  usage: "fast fund usdc fiat [--address <address>]",
+  options: ["--address"],
+  check: () => null,
+},
+"fund usdc crypto": {
+  usage: "fast fund usdc crypto <amount> --chain <chain> [--token <token>]",
+  options: ["--chain", "--token", "--eip-7702"],
+  check: (positionals, allArgv) => {
+    if (positionals.length < 4) return "Missing required argument: <amount>";
+    if (!allArgv.some((a) => a === "--chain" || a.startsWith("--chain=")))
+      return "Missing required option: --chain <chain>";
+    return null;
+  },
+},
+"fund fastusd": {
+  usage: "fast fund fastusd [--to <fast1...>] [--amount <decimal>]",
+  options: ["--to", "--amount"],
+  check: () => null,
+},
+```
+
+Note: `fund usdc crypto`'s positional check is now `< 4` (not `< 3`) because the chain has three positional tokens before the amount: `fund`, `usdc`, `crypto`, then `<amount>`.
+
+(c) Extend the parse-error post-processing (currently lines 341-364) to look up `${firstToken} ${secondToken} ${thirdToken}` when a third positional exists. Replace the `else if (firstToken && firstToken in SUBCOMMANDS)` branch as follows:
+
+Old:
+
+```ts
+} else if (firstToken && firstToken in SUBCOMMANDS) {
+  const subs = SUBCOMMANDS[firstToken];
+  const secondToken = positionals[1];
+  if (!secondToken) {
+    msg = `Missing subcommand for '${firstToken}'. Available: ${subs.join(", ")}.`;
+  } else if (!subs.includes(secondToken)) {
+    const s = suggest(secondToken, subs);
+    msg = s
+      ? `Unknown subcommand '${secondToken}' for '${firstToken}'. Did you mean '${s}'?`
+      : `Unknown subcommand '${secondToken}' for '${firstToken}'. Available: ${subs.join(", ")}.`;
+  } else {
+    // Valid subcommand but parse still failed — check for missing required args/options
+    const key = `${firstToken} ${secondToken}`;
+    const req = SUBCOMMAND_REQUIREMENTS[key];
+    if (req) {
+      const hint = req.check(positionals, argv);
+      if (hint) {
+        msg = `${hint}\n  Usage: ${req.usage}`;
+      } else if (req.options) {
+        const unknown = findUnknownFlag(argv, req.options);
+        if (unknown) msg = `Unknown option '${unknown}'.\n  Usage: ${req.usage}`;
+      }
+    }
+  }
+}
+```
+
+New:
+
+```ts
+} else if (firstToken && firstToken in SUBCOMMANDS) {
+  const subs = SUBCOMMANDS[firstToken];
+  const secondToken = positionals[1];
+  if (!secondToken) {
+    msg = `Missing subcommand for '${firstToken}'. Available: ${subs.join(", ")}.`;
+  } else if (!subs.includes(secondToken)) {
+    const s = suggest(secondToken, subs);
+    msg = s
+      ? `Unknown subcommand '${secondToken}' for '${firstToken}'. Did you mean '${s}'?`
+      : `Unknown subcommand '${secondToken}' for '${firstToken}'. Available: ${subs.join(", ")}.`;
+  } else {
+    // Try the deepest matching key (3-deep first, then 2-deep) so e.g.
+    // `fund usdc fiat` matches "fund usdc fiat" not "fund usdc".
+    const thirdToken = positionals[2];
+    const deepKey = thirdToken ? `${firstToken} ${secondToken} ${thirdToken}` : null;
+    const shallowKey = `${firstToken} ${secondToken}`;
+    const key =
+      deepKey && deepKey in SUBCOMMAND_REQUIREMENTS ? deepKey : shallowKey;
+    const req = SUBCOMMAND_REQUIREMENTS[key];
+    if (req) {
+      const hint = req.check(positionals, argv);
+      if (hint) {
+        msg = `${hint}\n  Usage: ${req.usage}`;
+      } else if (req.options) {
+        const unknown = findUnknownFlag(argv, req.options);
+        if (unknown) msg = `Unknown option '${unknown}'.\n  Usage: ${req.usage}`;
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 8: Verify tsc**
+
+Run: `cd app/cli && pnpm exec tsc --noEmit`
+Expected: empty output. If errors mention old names (`fundFiat`, `FundFiatArgs`, etc.), grep the codebase for stragglers and rename them.
+
+- [ ] **Step 9: Run all CLI tests**
+
+Run: `cd app/cli && pnpm exec vitest run`
+Expected: all tests pass.
+
+- [ ] **Step 10: Manual sanity check — exercise the new commands end-to-end**
+
+```bash
+cd app/cli && pnpm exec tsx src/main.ts fund fastusd --help
+cd app/cli && pnpm exec tsx src/main.ts fund usdc --help
+cd app/cli && pnpm exec tsx src/main.ts fund usdc fiat --help
+cd app/cli && pnpm exec tsx src/main.ts fund usdc crypto --help
+cd app/cli && pnpm exec tsx src/main.ts fund usdc bogus 2>&1 | head -3
+cd app/cli && pnpm exec tsx src/main.ts fund usdc 2>&1 | head -3
+```
+
+Expected: each `--help` invocation prints the contextual help; `fund usdc bogus` prints the "Unknown subcommand" hint; `fund usdc` prints the "Missing subcommand. Available: fiat, crypto" hint.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add app/cli/src/cli.ts \
+  app/cli/src/commands/index.ts \
+  app/cli/src/commands/fund/ \
+  app/cli/src/main.ts
+git commit -m "feat(cli): restructure fund into 2-deep tree (usdc fiat/crypto + fastusd)"
+```
+
+The `app/cli/src/commands/fund/` add picks up both the moved `usdc/` files and the new `fastusd.ts` handler from Step 5.
+
+---
+
+## Task 10: Sync agent skill doc and CLI README
+
+**Files:**
+- Modify: `skills/fast/SKILL.md`
+- Modify: `app/cli/README.md`
+- Read (and modify only if stale): `README.md`, `SPEC.md`
+
+This task has no automated tests; the verification is `markdownlint --fix` clean and a manual diff review.
+
+- [ ] **Step 1: Update `skills/fast/SKILL.md`**
+
+Open the file. Apply the following edits.
+
+(a) The funding-commands table near line 84-86:
+
+Old:
+
+```markdown
+| `fast fund crypto <amount>` | Bridge USDC from an EVM chain into the Fast account | `--chain <chain>` (required), `--eip-7702` (gasless) |
+| `fast fund fiat` | Open a fiat on-ramp (mainnet only) | `--network mainnet` |
+```
+
+New:
+
+```markdown
+| `fast fund usdc fiat` | Print a Ramp on-ramp URL for funding with USDC (mainnet only). Lands as **fastUSDC**. | `--network mainnet`, `--address` |
+| `fast fund usdc crypto <amount>` | Bridge USDC from an EVM chain into the Fast account. Lands as **fastUSDC**. | `--chain <chain>` (required), `--token`, `--eip-7702` (gasless) |
+| `fast fund fastusd` | Print an `app.fast.xyz/send` URL that opens the unified Fast funding page (mainnet only). Funds **fastUSD** (Fast-native, distinct from fastUSDC). | `--to <fast1...>`, `--amount <decimal>` |
+```
+
+(b) The `--token` row in the `send` table around line 98:
+
+Old:
+
+```markdown
+| `--token <TOKEN>` | Token to send (**always specify explicitly**) | `USDC` (default; `testUSDC` is an alias on testnet) |
+```
+
+New:
+
+```markdown
+| `--token <TOKEN>` | Token to send. If omitted, defaults to `fastUSD` on mainnet (Fast→Fast) and `testUSDC` on testnet. | `USDC`, `fastUSDC`, `fastUSD`, `testUSDC` |
+```
+
+(c) The references in the EVM-address note (around line 172):
+
+Old:
+
+```markdown
+When running `fast fund crypto` or `fast send --from-chain <chain>`, the CLI
+```
+
+New:
+
+```markdown
+When running `fast fund usdc crypto` or `fast send --from-chain <chain>`, the CLI
+```
+
+(d) The walkthrough section header (around line 270) and its examples (around lines 273, 288, 303):
+
+Old:
+
+```markdown
+### 4. Fund from EVM → Fast (`fast fund crypto`)
+
+```sh
+fast fund crypto 50 --chain arbitrum-sepolia
+```
+
+...
+
+```sh
+fast fund crypto 50 --chain base --eip-7702
+```
+
+...
+
+```sh
+fast fund fiat --network mainnet
+# → prints an on-ramp URL
+```
+```
+
+New:
+
+```markdown
+### 4. Fund from EVM → Fast (`fast fund usdc crypto`)
+
+```sh
+fast fund usdc crypto 50 --chain arbitrum-sepolia
+```
+
+...
+
+```sh
+fast fund usdc crypto 50 --chain base --eip-7702
+```
+
+...
+
+```sh
+fast fund usdc fiat --network mainnet
+# → prints a Ramp on-ramp URL (USDC → fastUSDC)
+```
+
+### 6. Fund fastUSD via the unified Fast web app
+
+```sh
+fast fund fastusd --network mainnet
+# → prints app.fast.xyz/send?to=<your-fast-address>
+fast fund fastusd --network mainnet --amount 25
+# → adds &amount=25
+```
+
+This URL is mainnet-only and funds **fastUSD** (a Fast-native token, separate
+from fastUSDC).
+```
+
+(Adjust the heading number `### 6.` if it conflicts with an existing section — match the local numbering.)
+
+- [ ] **Step 2: Run markdownlint --fix on SKILL.md**
+
+```bash
+pnpm dlx markdownlint-cli --fix skills/fast/SKILL.md
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Update `app/cli/README.md`**
+
+Apply the following edits.
+
+(a) Quickstart line (around line 38-39):
+
+Old:
+
+```bash
+# Bridge from Arbitrum Sepolia to Fast
+fast fund crypto 50 --chain arbitrum-sepolia
+```
+
+New:
+
+```bash
+# Bridge from Arbitrum Sepolia to Fast (USDC → fastUSDC)
+fast fund usdc crypto 50 --chain arbitrum-sepolia
+
+# Or get a unified Fast web-app URL to fund fastUSD (mainnet only)
+fast fund fastusd --amount 50
+```
+
+(b) Section `### \`fast fund fiat\`` (around line 243-258). Replace the entire section with:
+
+```markdown
+### `fast fund usdc fiat`
+
+Get a fiat on-ramp URL for funding a Fast address with USDC. The URL targets
+[ramp.fast.xyz](https://ramp.fast.xyz). The deposit lands on Fast as
+**fastUSDC** (the EVM-bridged variant of USDC).
+
+```bash
+fast fund usdc fiat --network mainnet
+```
+
+**Requirements:**
+- Mainnet only (Ramp does not support testnet).
+- Active account or `--address <fast1...>`.
+```
+
+(c) Section `### \`fast fund crypto <amount>\`` (around line 261-276). Replace with:
+
+```markdown
+### `fast fund usdc crypto <amount>`
+
+Bridge USDC from an EVM chain to the Fast network. The deposit lands as
+**fastUSDC** on Fast.
+
+```bash
+fast fund usdc crypto 10.5 --chain arbitrum-sepolia --token USDC
+```
+
+**Positional arguments:**
+- `<amount>` — Human-readable amount to bridge (e.g., `10.5`).
+
+**Options:**
+- `--chain <chain>` — Source EVM chain (required).
+- `--token <token>` — Token symbol or token ID (defaults to `USDC` / `testUSDC`).
+- `--eip-7702` — Use the smart deposit flow (gas paid in USDC via paymaster).
+```
+
+(d) Add a new section right after `### \`fast fund usdc crypto\``:
+
+```markdown
+### `fast fund fastusd`
+
+Print an `app.fast.xyz/send` URL that opens the unified Fast web app to fund
+your account with **fastUSD** (a Fast-native token, separate from fastUSDC).
+The web app handles fiat-onramp, crypto-bridge, and wallet-to-wallet funding
+under the hood; the CLI's job is just to produce the URL.
+
+```bash
+fast fund fastusd
+# → https://app.fast.xyz/send?to=fast1...
+
+fast fund fastusd --amount 25
+# → https://app.fast.xyz/send?to=fast1...&amount=25
+
+fast fund fastusd --to fast1someoneelse --amount 10
+# → https://app.fast.xyz/send?to=fast1someoneelse&amount=10
+```
+
+**Options:**
+- `--to <fast1...>` — Recipient Fast address (default: active account).
+- `--amount <decimal>` — Optional amount; if omitted, the web app prompts.
+
+**Requirements:**
+- Mainnet only.
+```
+
+(e) End-to-end example around line 386-390:
+
+Old:
+
+```bash
+# 2. Get a fiat on-ramp URL
+fast fund fiat --network mainnet --address fast1...
+```
+
+New:
+
+```bash
+# 2. Get a fiat on-ramp URL (USDC → fastUSDC)
+fast fund usdc fiat --network mainnet --address fast1...
+
+# 2b. Or open the unified Fast web app to fund fastUSD
+fast fund fastusd --network mainnet
+```
+
+- [ ] **Step 4: Run markdownlint --fix on the README**
+
+```bash
+pnpm dlx markdownlint-cli --fix app/cli/README.md
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Scan root `README.md` and `SPEC.md` for stale references**
+
+Run:
+
+```bash
+grep -n -E "fund (fiat|crypto)|testUSDC|fund-fiat|fund-crypto" README.md SPEC.md 2>/dev/null
+```
+
+If matches appear: update them in place using the same patterns as above
+(`fund fiat` → `fund usdc fiat`, etc.) and run `pnpm dlx markdownlint-cli
+--fix <file>` for each modified file. If no matches: skip (no need to invent
+new sections).
+
+- [ ] **Step 6: Manual sanity-check the rendered docs**
+
+Read each modified file end-to-end one more time. Look for:
+- Inconsistent token names (USDC vs fastUSDC vs fastUSD).
+- Broken markdown anchors (any `#fast-fund-fiat` ids that should now be `#fast-fund-usdc-fiat`).
+- Out-of-order section numbering after additions.
+
+Fix in place.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/fast/SKILL.md app/cli/README.md
+# Add README.md and SPEC.md too if Step 5 modified them.
+git commit -m "docs(cli): sync fund command tree and fastUSD adoption"
+```
+
+---
+
+## Task 11: Cross-cutting verification + PR prep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full repo tsc clean**
+
+```bash
+cd app/cli && pnpm exec tsc --noEmit
+cd packages/x402-client && pnpm exec tsc --noEmit
+cd packages/fast-sdk && pnpm exec tsc --noEmit
+```
+
+Expected: every command exits 0 with empty output. If `packages/fast-sdk` reports errors that pre-date this branch (compare against `git diff origin/main -- packages/fast-sdk/`), they are out of scope and should be flagged but not "fixed" in this branch.
+
+- [ ] **Step 2: Full vitest run from each modified package**
+
+```bash
+cd app/cli && pnpm exec vitest run
+cd packages/x402-client && pnpm exec vitest run
+```
+
+Expected: all tests pass. If any test runs flaky (e.g., network), retry once; on persistent flake, capture the failure and pause to ask the user before proceeding.
+
+- [ ] **Step 3: Optional — full monorepo build**
+
+```bash
+cd /home/yuqing/Documents/Code/fast-sdk && pnpm build
+```
+
+Expected: build succeeds. If it fails for unrelated reasons (e.g., a sibling package has a pre-existing issue on main), confirm with `git stash && pnpm build` on a clean working tree — if it still fails, the issue is pre-existing and out of scope.
+
+- [ ] **Step 4: Manual smoke test on the dev CLI**
+
+```bash
+cd app/cli
+pnpm exec tsx src/main.ts --help
+pnpm exec tsx src/main.ts fund --help
+pnpm exec tsx src/main.ts fund fastusd --help
+pnpm exec tsx src/main.ts fund usdc fiat --help
+pnpm exec tsx src/main.ts fund usdc crypto --help
+pnpm exec tsx src/main.ts fund fastusd --network mainnet --to fast1abc --amount 10
+# Expected output: an https://app.fast.xyz/send?to=fast1abc&amount=10 URL
+pnpm exec tsx src/main.ts fund fastusd --network testnet
+# Expected: InvalidUsageError "fastUSD funding is only available on mainnet…"
+```
+
+If any output mismatches what's documented in the README or SKILL.md, fix the discrepancy and re-run from Step 1.
+
+- [ ] **Step 5: Final `git status` review**
+
+```bash
+git status
+git log origin/main..HEAD --oneline
+```
+
+Expected status: clean working tree. Expected log: ~10 commits (one per task above), in conventional-commit form.
+
+If there are uncommitted changes, decide per-file: legitimate fix → commit with a `chore` or `fix` message; experimental/forgotten → revert.
+
+- [ ] **Step 6: Hand off**
+
+Pause and report to the user:
+
+```text
+Implementation complete on branch `feat/cli-fund-fastusd`. <N> commits ahead of origin/main:
+  <list of commits>
+
+All checks green:
+  - tsc (app/cli, packages/x402-client, packages/fast-sdk)
+  - vitest (app/cli, packages/x402-client)
+  - manual smoke test of `fund fastusd` URL output
+
+Ready to push and open PR? (Will use the same shape as PR #85: Summary / Test plan / Out of scope, with the Generated-with-Claude-Code trailer.)
+```
+
+Wait for user confirmation before running `git push -u origin feat/cli-fund-fastusd` or `gh pr create`.
+
+---
+
+## Self-review checklist (run before considering this plan finished)
+
+- [ ] Every spec section maps to a task: `fund` restructure → 8+9; fastUSD config → 2+4; resolver extension → 3; send default → 5; pay/x402-client cosmetic fix → 6+7; doc sync → 10.
+- [ ] No `TBD` / `TODO` / `implement later` / `add appropriate error handling` / `similar to Task N` (without code) phrases anywhere.
+- [ ] Type names consistent across tasks: `FundUsdcFiatArgs`, `FundUsdcCryptoArgs`, `FundFastUsdArgs`, `selectSendTokenName`, `resolveDefaultToken`, `lookupTokenNameById`, `labelAssetForPayment`, `buildFundFastUsdUrl`. Method/discriminant names: `fundUsdcFiat` (`"fund-usdc-fiat"`), `fundUsdcCrypto` (`"fund-usdc-crypto"`), `fundFastUsd` (`"fund-fastusd"`).
+- [ ] Each task ends with one commit; commit message style is conventional and matches the type of change (`feat`, `refactor`, `chore`, `docs`, `fix`).
+- [ ] Verification commands are spelled out: `cd app/cli && pnpm exec vitest run`, `cd app/cli && pnpm exec tsc --noEmit`, etc.

--- a/docs/superpowers/specs/2026-05-06-cli-fund-restructure-and-fastusd-design.md
+++ b/docs/superpowers/specs/2026-05-06-cli-fund-restructure-and-fastusd-design.md
@@ -1,0 +1,512 @@
+<!-- markdownlint-disable MD013 -->
+# CLI `fund` restructure and fastUSD adoption — Design
+
+## Goal
+
+Two coordinated changes in `app/cli`, plus light cosmetic fixes in
+`packages/x402-client`:
+
+1. **`fund` command restructure.** Re-shape the `fund` subcommand
+   group to reflect the *target token* of each funding path, and
+   add a new path for funding `fastUSD` (a Fast-native token) via
+   the unified `app.fast.xyz/send` web app.
+2. **`fastUSD` adoption.** Make `fastUSD` the default token for
+   `fast send` Fast→Fast on **mainnet**, register `fastUSD` in the
+   bundled network config, and stop mislabeling x402 payments as
+   `USDC` in display/log/history when the actual asset paid was
+   different.
+
+The work goes on a fresh branch off `main`. The `feat/multisig-cli`
+branch (PR #85) is untouched.
+
+## Background
+
+### Today's `fund` group
+
+`fast fund` has two subcommands:
+
+| Command                                  | Behavior                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------- |
+| `fast fund fiat`                         | Prints `https://ramp.fast.xyz/?to=<addr>` (Ramp → fastUSDC). Mainnet only.|
+| `fast fund crypto <amount> --chain <c>`  | Executes an EVM→Fast bridge via `@fastxyz/allset-sdk` → fastUSDC on Fast. |
+
+Both paths land on **fastUSDC** — the EVM-bridged Fast representation
+of USDC.
+
+### `fastUSD` vs `fastUSDC`
+
+`fastUSD` is a separate Fast-native token (mint-only, no EVM
+counterpart). `fastUSDC` is the EVM-bridged variant. They are not
+the same token and `fastUSDC` is **not** being deprecated.
+
+The unified Fast web app at `app.fast.xyz/send` lets a user fund a
+Fast wallet with `fastUSD` via fiat-on-ramp, crypto-bridge, or
+wallet-to-wallet, all in one place. The CLI should be able to emit
+the URL that opens that page for a given recipient and amount —
+nothing more. The CLI does not execute the funding itself.
+
+### x402 token reality
+
+`fast pay` is the CLI front-end for the x402 HTTP-payment protocol
+(`@fastxyz/x402-client`). The client does **not** choose the token
+to pay with — the server returns a `paymentRequired.accepts[]`
+array, each entry naming a `network`, `payTo`, `maxAmountRequired`,
+and `asset` (token ID). The client picks one of the accepted
+entries and pays in whatever asset that entry specifies.
+
+Despite this, three places in the CLI / x402-client hardcode the
+string `"USDC"` regardless of the actual asset paid. They are
+display-only, but they lie:
+
+- [pay.ts:94](app/cli/src/commands/pay.ts#L94) — dry-run printer:
+  `Asset: ${opt.asset ?? "USDC"}`.
+- [pay.ts:191](app/cli/src/commands/pay.ts#L191) — history entry:
+  `tokenName: "USDC"` hardcoded.
+- [fast.ts:137](packages/x402-client/src/fast.ts#L137) — verbose
+  log: `→ ${amountHuman} USDC`.
+
+Once `fastUSD` lands as a registered token, these strings will
+mislabel any `fastUSD` payment as `USDC`.
+
+### Bundled network config
+
+`app/cli/src/config/networks.json` defines two networks (`testnet`,
+`mainnet`). Each network has an `allset` block with per-EVM-chain
+token registries. Today every chain registers a single entry —
+`testUSDC` on testnet, `USDC` on mainnet — keyed to its EVM
+address and a network-wide Fast token ID.
+
+There is no concept of a Fast-native token in the schema because
+every existing token has an EVM counterpart. `fastUSD` is the
+first exception.
+
+## Scope
+
+### In scope
+
+- Re-shape `fund` subcommand tree to two-deep: `fund usdc fiat`,
+  `fund usdc crypto`, plus new `fund fastusd`.
+- New `fund fastusd` URL-emitter command (mainnet-only).
+- New mainnet `fastTokens.fastUSD` entry in `networks.json`.
+- `send` Fast→Fast default token resolution: prefer mainnet
+  `fastUSD` when no `--token` is supplied.
+- Extend `resolveToken` to consult `fastTokens` when no chain
+  context is given.
+- Replace the three cosmetic `"USDC"` mislabels with the actual
+  asset name (resolved against the network's token registry).
+- Doc sync: `skills/fast/SKILL.md`, `app/cli/README.md`, and any
+  stale references in root `README.md` / `SPEC.md`.
+
+### Out of scope
+
+- `feat/multisig-cli` branch (PR #85). Untouched.
+- `@fastxyz/allset-sdk` removal — kept; `send` bridging routes and
+  `fund usdc crypto` still depend on it.
+- `x402-types`, `x402-facilitator`, `x402-server` packages — not
+  modified. Their `usdcAddress` / `usdcName` / `usdcVersion`
+  fields are EVM-side EIP-3009 settlement concerns; `fastUSD`
+  has no EVM counterpart and so cannot be settled there.
+- `parsePrice` regex stripping `/usdc/i` from price strings — left
+  alone; price-string parsing is not on a `fastUSD` path yet.
+- `bridgeFastusdcToUsdc` rename in `x402-client` — cosmetic only,
+  defer to a separate cleanup if ever needed.
+- testnet `fastUSD` — does not exist; testnet behavior is unchanged
+  (testnet `send` Fast→Fast default stays `testUSDC`; `fund
+  fastusd` errors on testnet).
+- Any QR-code rendering or browser-launch (`--open`) features for
+  the new URL command — modern terminals make URLs ctrl-clickable;
+  YAGNI.
+- Removing or renaming `fund fiat` / `fund crypto` without a
+  replacement — both behaviors are preserved, just under new
+  command paths (`fund usdc fiat` / `fund usdc crypto`).
+
+## Architecture
+
+```text
+app/cli
+  src/
+    cli.ts                     (modified: new arg types, new optique parsers)
+    main.ts                    (modified: 2-deep dispatch for `fund usdc *`)
+    commands/
+      index.ts                 (modified: swap fund-fiat/fund-crypto for fund-usdc-fiat/fund-usdc-crypto/fund-fastusd)
+      fund/
+        usdc/
+          fiat.ts              (RENAMED from fund/fiat.ts; logic unchanged)
+          crypto.ts            (RENAMED from fund/crypto.ts; logic unchanged)
+        fastusd.ts             (NEW)
+      pay.ts                   (modified: B2-fix display/history truth)
+      send.ts                  (modified: B1 — mainnet default = fastUSD)
+    config/
+      networks.json            (modified: mainnet gains fastTokens.fastUSD)
+    schemas/
+      networks.ts              (modified: BundledNetworksSchema gains optional fastTokens)
+    services/
+      token-resolver.ts        (modified: consult fastTokens for no-chain lookups)
+
+packages/x402-client
+  src/
+    fast.ts                    (modified: log line shows actual asset, not "USDC")
+
+skills/fast/SKILL.md           (modified)
+app/cli/README.md              (modified)
+README.md, SPEC.md             (scanned; updated only if stale references found)
+```
+
+`@fastxyz/sdk`, `@fastxyz/schema`, `@fastxyz/allset-sdk`,
+`@fastxyz/x402-types`, `@fastxyz/x402-facilitator`,
+`@fastxyz/x402-server` are unchanged.
+
+### Data flow: `fast fund fastusd`
+
+1. CLI parses `fund fastusd` (no positional args).
+2. Active network must be `mainnet`. If not, fail with
+   `InvalidUsageError` mirroring `fund usdc fiat`'s testnet check.
+3. Resolve `--to`: if `args.to` is set, validate it starts with
+   `fast1`; else look up the active account and use its
+   `fastAddress`.
+4. Build the URL:
+   - Base: `https://app.fast.xyz/send`
+   - Append `?to=<addr>` always (since `to` always resolves to a
+     value).
+   - Append `&amount=<n>` only if `--amount` was supplied. The
+     web app tolerates omission.
+5. Print the URL with the same human-line wrapper that `fund usdc
+   fiat` uses today (`Open this URL in your browser to fund your
+   account: <url>`).
+6. `output.ok({ url, address })` for JSON mode.
+
+No transaction. No history record. No allset, no x402, no signer.
+
+### Data flow: `fast send <recipient> <amount>` (Fast→Fast, mainnet, no `--token`)
+
+1. CLI loads active account, resolves the recipient as a `fast1*`
+   address.
+2. `resolveToken(undefined, network, undefined)` is called (no
+   `--token`, no `--from-chain` / `--to-chain` so no chain context).
+3. **New behavior:** `resolveToken` first checks
+   `network.fastTokens` for a default token. On mainnet,
+   `fastTokens.fastUSD` is present → return its `fastTokenId` and
+   `decimals`. On testnet, `fastTokens` is absent → fall through
+   to the existing per-chain scan, which finds `testUSDC` (current
+   behavior preserved).
+4. `--token <name>` overrides this default unconditionally — name
+   is looked up first in `fastTokens`, then in chain-scoped
+   tokens, matching today's resolver semantics.
+5. Rest of `send` Fast→Fast is unchanged.
+
+For EVM bridging routes (`--from-chain` / `--to-chain`),
+`resolveToken` is called with chain context and only consults
+`allset.chains[chain].tokens` — `fastTokens` is not consulted
+because EVM bridging needs an EVM-side token. Behavior unchanged.
+
+### Data flow: x402 display/history truth (B2-fix)
+
+1. **Dry-run display.** [pay.ts:94](app/cli/src/commands/pay.ts#L94)
+   currently prints `Asset: ${opt.asset ?? "USDC"}`. New behavior:
+   resolve `opt.asset` (a token-ID hex string) against the network's
+   token registry. If the registry has an entry whose `fastTokenId`
+   matches, print that entry's display name; else print the short
+   hex (`opt.asset`). Never print `"USDC"` for a non-USDC asset.
+2. **History `tokenName`.**
+   [pay.ts:191](app/cli/src/commands/pay.ts#L191) currently writes
+   `tokenName: "USDC"` regardless of what was paid. New behavior:
+   `result.payment` already includes the network and amount; add
+   `asset` to the `X402PayResult.payment` shape (in
+   `x402-client/types.ts`) so the CLI can map it to a registry
+   entry and write the correct `tokenName`. Fall back to
+   `"unknown"` if the asset is not registered.
+3. **Verbose log line.**
+   [fast.ts:137](packages/x402-client/src/fast.ts#L137) currently
+   logs `→ ${amountHuman} USDC`. Change to `→ ${amountHuman}
+   (asset ${fastReq.asset})`. The client does not have a registry
+   to translate the hex into a name, so showing the hex is the
+   right truth-level output for a verbose log.
+
+These are display-only edits; the protocol payload, the actual
+on-chain transfer, and the wire format are unchanged.
+
+## Components
+
+### `cli.ts` parser additions
+
+Today's `cli.ts` defines optique parsers for each subcommand and
+exports an `Args` union plus typed argument records (e.g.
+`FundFiatArgs`). The change adds three new arg shapes:
+
+- `FundUsdcFiatArgs` — same fields as today's `FundFiatArgs`
+  (`address?: string` plus globals).
+- `FundUsdcCryptoArgs` — same fields as today's `FundCryptoArgs`
+  (`amount: string`, `chain: string`, `token?: string`,
+  `eip7702: boolean` plus globals).
+- `FundFastUsdArgs` — `to?: string`, `amount?: string` plus
+  globals.
+
+The original `FundFiatArgs` / `FundCryptoArgs` types are renamed in
+place (no aliasing — internal-only project, breaking renames
+acceptable per user direction).
+
+### `main.ts` two-deep dispatch
+
+`KNOWN_COMMANDS` keeps `"fund"`. `SUBCOMMANDS["fund"]` becomes
+`["usdc", "fastusd"]` (a list of *first-level* subcommand
+keywords). The dispatcher recognizes a third positional token when
+`subcommand === "usdc"` and maps:
+
+- `fund usdc fiat`   → registry cmd `"fund-usdc-fiat"`
+- `fund usdc crypto` → registry cmd `"fund-usdc-crypto"`
+- `fund fastusd`     → registry cmd `"fund-fastusd"`
+
+`SUBCOMMAND_REQUIREMENTS` is keyed by the registry cmd string
+(`"fund-usdc-fiat"`, etc.) — the existing flat-string scheme works
+fine; only the dispatch routing changes shape. Unknown
+combinations (`fund usdc bogus`, `fund bogus`) produce the same
+shape of error that today's unknown subcommand produces (help
+text + non-zero exit).
+
+If the user types `fund usdc` with no third token, error with a
+help message listing `fiat` and `crypto`.
+
+### `commands/fund/fastusd.ts`
+
+Mirrors the structure of [fund/fiat.ts](app/cli/src/commands/fund/fiat.ts):
+
+```ts
+const APP_BASE = "https://app.fast.xyz/send";
+
+export const fundFastUsd: Command<FundFastUsdArgs> = {
+  cmd: "fund-fastusd",
+  handler: (args) =>
+    Effect.gen(function* () {
+      const accounts = yield* AccountStore;
+      const output = yield* Output;
+      const config = yield* ClientConfig;
+
+      if (config.network !== "mainnet") {
+        return yield* Effect.fail(new InvalidUsageError({
+          message:
+            `fastUSD funding is only available on mainnet. ` +
+            `Current network: ${config.network}. ` +
+            `Switch with --network mainnet.`,
+        }));
+      }
+
+      let address: string;
+      if (args.to) {
+        if (!args.to.startsWith("fast1")) {
+          return yield* Effect.fail(new InvalidAddressError({
+            message: `Invalid Fast address "${args.to}". Must start with fast1.`,
+          }));
+        }
+        address = args.to;
+      } else {
+        const account = yield* accounts.resolveAccount(config.account);
+        address = account.fastAddress;
+      }
+
+      const params = new URLSearchParams({ to: address });
+      if (args.amount !== undefined) {
+        // Validate amount is a positive decimal; reuse existing parser pattern
+        // (defer to plan task — see "amount validation" below)
+        params.set("amount", args.amount);
+      }
+      const url = `${APP_BASE}?${params.toString()}`;
+
+      yield* output.humanLine("Open this URL in your browser to fund your account:");
+      yield* output.humanLine("");
+      yield* output.humanLine(`  ${url}`);
+      yield* output.humanLine("");
+      yield* output.ok({ url, address });
+    }),
+};
+```
+
+**Amount validation.** Validate that `--amount`, if supplied, is
+a non-empty positive decimal string. Reject `0`, negative, NaN,
+empty. Don't try to enforce decimal precision (the web app
+handles that). Errors use `InvalidAmountError`.
+
+### `config/networks.json` — mainnet `fastTokens`
+
+Mainnet entry gains a top-level `fastTokens` map (sibling of
+`allset`). Testnet does not.
+
+```jsonc
+{
+  "mainnet": {
+    "url": "https://api.fast.xyz/proxy-rest",
+    "explorerUrl": "https://explorer.fast.xyz",
+    "networkId": "fast:mainnet",
+    "allset": { /* unchanged */ },
+    "fastTokens": {
+      "fastUSD": {
+        "fastTokenId": "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+        "decimals": 6
+      }
+    }
+  }
+}
+```
+
+`decimals: 6` matches USDC and the standard for stablecoins.
+
+### `schemas/networks.ts`
+
+`BundledNetworksSchema` (Effect Schema) gains an optional
+`fastTokens` field on each `NetworkConfig`. Shape:
+
+```ts
+fastTokens: Schema.optional(
+  Schema.Record({
+    key: Schema.String,
+    value: Schema.Struct({
+      fastTokenId: Schema.String, // 0x-prefixed 32-byte hex
+      decimals: Schema.Number,
+    }),
+  }),
+);
+```
+
+The optionality is real — testnet legitimately has none. Custom
+user-added networks may also omit it.
+
+### `services/token-resolver.ts`
+
+Today's signature: `resolveToken(tokenName, networkConfig, chain?)
+→ ResolvedToken`. Two changes:
+
+1. **Without chain context** (`chain === undefined`): if
+   `networkConfig.fastTokens?.[tokenName]` exists, return it
+   directly. Otherwise fall through to today's per-chain scan
+   (preserves testnet behavior).
+2. **Default-token resolution** (caller passes a sentinel like
+   `tokenName === undefined`): when neither chain nor token is
+   given, return the network's preferred Fast-native default if
+   one exists. Concretely: if `networkConfig.fastTokens` has
+   exactly one entry, that entry is the default; if it has
+   multiple, look for a key called `"fastUSD"`; if neither,
+   fall back to today's "first chain's first token" rule.
+
+**With chain context**: behavior unchanged — only
+`allset.chains[chain].tokens` is consulted. `fastTokens` is
+ignored on EVM-bridge paths because no EVM-side counterpart
+exists.
+
+**New helper for B2-fix (id → name).** Today's resolver maps
+`name → id`. The pay.ts display/history fix needs the inverse:
+given a `fastTokenId` hex from a server's payment requirement,
+find the matching display name. Add a sibling helper
+(`lookupTokenNameById(networkConfig, fastTokenId) → string |
+undefined`) that scans both `fastTokens` and
+`allset.chains[*].tokens` and returns the first key whose
+`fastTokenId` matches. Returns `undefined` if no match — callers
+fall back to the short hex / `"unknown"`.
+
+The exact API shape (whether to add an explicit
+`resolveDefaultToken(networkConfig)` helper or to fold the default
+logic into `resolveToken` with a sentinel) will be decided in the
+plan; the spec only fixes the *behavior*.
+
+### `commands/send.ts` — mainnet default
+
+Today, when `--token` is omitted on a Fast→Fast send, the resolver
+scans the network's chains for the first token (typically
+`testUSDC` on testnet, `USDC` on mainnet). After this change:
+
+- Mainnet: returns `fastUSD` (sourced from `fastTokens.fastUSD`).
+- Testnet: returns `testUSDC` (unchanged — no `fastTokens` on
+  testnet).
+
+The `--token` flag continues to override unconditionally; it
+resolves first in `fastTokens`, then in chain-scoped tokens.
+
+### `commands/pay.ts` and `packages/x402-client/src/fast.ts` — B2-fix
+
+Three edits as described in the data-flow section above. The
+[types.ts](packages/x402-client/src/types.ts) `X402PayResult.payment`
+shape gains an `asset?: string` field carrying the actual asset hex
+that the server demanded; `pay.ts` translates it to a name via
+the network's token registry (or `"unknown"`).
+
+The dry-run display fallback uses the same translator. The
+verbose log in `fast.ts` shows the raw hex (no registry available
+in the package).
+
+## Error handling
+
+| Scenario                                          | Error                                                              |
+| ------------------------------------------------- | ------------------------------------------------------------------ |
+| `fund fastusd` on testnet                         | `InvalidUsageError` (same shape as today's `fund usdc fiat`)       |
+| `fund fastusd --to <bad>`                         | `InvalidAddressError` — must start with `fast1`                    |
+| `fund fastusd --amount <bad>`                     | `InvalidAmountError` — non-empty positive decimal required         |
+| `fund usdc <unknown-third-token>`                 | help-text + non-zero exit (matches today's unknown subcommand)     |
+| `fund usdc` with no third token                   | help-text + non-zero exit                                          |
+| `send` mainnet, no `--token`, `fastUSD` missing   | `TokenNotFoundError` after falling back to chain scan              |
+| `pay` resolves an unknown asset hex               | display falls back to short hex; history `tokenName: "unknown"`    |
+
+## Testing
+
+Vitest from `app/cli/`:
+
+- **`fund fastusd`** — URL shape (with/without `--amount`), default
+  `--to` resolves to active account, explicit `--to` validation,
+  mainnet-only error on testnet, JSON output shape.
+- **`send` Fast→Fast token default** — mainnet returns `fastUSD`,
+  testnet returns `testUSDC`, explicit `--token` overrides on both.
+- **`token-resolver`** — `fastTokens` lookup wins over chain scan
+  when no chain context; chain context still ignores `fastTokens`.
+- **`pay`** — dry-run display and history `tokenName` reflect the
+  actual server-supplied asset; unknown asset hex falls back to
+  hex string / `"unknown"`.
+- **Existing fund tests** — renamed and re-pathed for `fund usdc
+  fiat` / `fund usdc crypto`; behavior assertions unchanged.
+
+Vitest from `packages/x402-client/`:
+
+- **`fast.ts` log line** — verbose log shows the raw asset hex,
+  not `"USDC"`. (If there is no existing test for the verbose
+  log, add a focused one.)
+
+`tsc --noEmit` clean for `app/cli`, `packages/fast-sdk`, and
+`packages/x402-client`.
+
+## Doc sync
+
+- [skills/fast/SKILL.md](skills/fast/SKILL.md) — update the
+  funding-flow section, command tables (~L84-86, L98, L172, L270,
+  L288, L303), token-name guidance, and any walkthrough that
+  invokes `fund fiat` / `fund crypto`.
+- [app/cli/README.md](app/cli/README.md) — update sections at
+  L38-42 (quickstart), L243-275 (command reference), L386-390
+  (end-to-end example), and `--token` defaults wherever mentioned.
+- Scan [README.md](README.md) and [SPEC.md](SPEC.md) for stale
+  `fund fiat` / `fund crypto` / `testUSDC` / `USDC` defaults.
+  Update only if there's a real reference; do not invent new
+  sections.
+
+After editing each `.md` file, run `pnpm dlx markdownlint-cli
+--fix <file>` per the global formatting rule.
+
+## Build sequence
+
+A coarse ordering for the implementation plan to refine:
+
+1. **Schema and config first.** Extend
+   `BundledNetworksSchema` with optional `fastTokens`; add the
+   mainnet entry to `networks.json`. Land this with no consumers
+   to keep the diff narrow.
+2. **Token resolver extension.** Implement the `fastTokens`
+   lookup and default-token logic. Add resolver tests.
+3. **`send` Fast→Fast default.** Wire the resolver change into
+   `send.ts`. Add tests.
+4. **B2-fix in `x402-client`.** Surface `asset` on
+   `X402PayResult.payment`; update verbose log. Tests.
+5. **B2-fix in `pay.ts`.** Use `asset` for history + display. Tests.
+6. **`fund` restructure.** Move files, add `fundFastUsd`, update
+   `cli.ts` parsers, `commands/index.ts` registry, and
+   `main.ts` dispatch (this is the biggest single change). Tests.
+7. **Doc sync.** SKILL.md, README, scan SPEC. Markdownlint.
+8. **Cross-cutting review.** `tsc --noEmit`, full vitest, manual
+   sanity check of `fast fund fastusd` URL output.
+
+One commit per task, conventional-style messages (`feat(cli): ...`,
+`refactor(cli): ...`, `chore(cli): ...`, `docs(cli): ...`).

--- a/packages/x402-client/src/evm.ts
+++ b/packages/x402-client/src/evm.ts
@@ -304,6 +304,7 @@ export async function handleEvmPayment(
       amount: amountHuman,
       recipient: evmReq.payTo,
       txHash: settleTxHash,
+      asset: evmReq.asset ?? evmChainConfig.usdcAddress,
       bridged,
       bridgeTxHash,
     },

--- a/packages/x402-client/src/fast.ts
+++ b/packages/x402-client/src/fast.ts
@@ -138,7 +138,7 @@ export async function handleFastPayment(
 
   const amountHuman = toHuman(fastReq.maxAmountRequired, 6);
   log(`[Fast] Building transaction via TransactionBuilder...`);
-  log(`  Amount: ${fastReq.maxAmountRequired} raw → ${amountHuman} USDC`);
+  log(`  Amount: ${fastReq.maxAmountRequired} raw → ${amountHuman} (asset ${fastReq.asset})`);
   const txStartTime = Date.now();
 
   const networkId = resolveNetworkId(fastReq.network);
@@ -216,6 +216,7 @@ export async function handleFastPayment(
       amount: amountHuman,
       recipient: fastReq.payTo,
       txHash,
+      asset: fastReq.asset,
     },
     note: paidRes.ok
       ? `Fast payment of ${amountHuman} successful. Content delivered.`

--- a/packages/x402-client/src/types.ts
+++ b/packages/x402-client/src/types.ts
@@ -112,7 +112,12 @@ export interface PaymentDetails {
   amount: string;
   recipient: string;
   txHash: string;
-  /** The token id (hex string) actually paid, mirrored from the server's payment requirement. */
+  /**
+   * The canonical identifier for the asset actually paid, mirrored from the
+   * server's payment requirement. Shape depends on the network: a Fast token
+   * id hex (e.g. `0xc655a1...`) for Fast networks, an ERC-20 contract address
+   * (e.g. `0xA0b8...`) for EVM networks.
+   */
   asset?: string;
   bridged?: boolean;
   bridgeTxHash?: string;

--- a/packages/x402-client/src/types.ts
+++ b/packages/x402-client/src/types.ts
@@ -112,6 +112,8 @@ export interface PaymentDetails {
   amount: string;
   recipient: string;
   txHash: string;
+  /** The token id (hex string) actually paid, mirrored from the server's payment requirement. */
+  asset?: string;
   bridged?: boolean;
   bridgeTxHash?: string;
 }

--- a/packages/x402-client/tests/index.test.ts
+++ b/packages/x402-client/tests/index.test.ts
@@ -174,4 +174,25 @@ describe('x402-client', () => {
       expect(capturedMethod).toBe('POST');
     });
   });
+
+  describe('PaymentDetails.asset', () => {
+    it('exposes the asset hex on the result so callers can label payments correctly', async () => {
+      // This is a structural assertion — it confirms the type carries `asset`
+      // and that fast.ts populates it from the server's payment requirement.
+      // We do NOT exercise the full Fast network flow (that's covered
+      // by integration tests). We do a minimal handler-level check by
+      // constructing a result via the public type and verifying TS accepts it.
+      const sample: import('../src/types.js').PaymentDetails = {
+        network: 'fast-mainnet',
+        amount: '1.0',
+        recipient: 'fast1abc',
+        txHash: '0xdead',
+        asset:
+          '0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb',
+      };
+      expect(sample.asset).toBe(
+        '0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb',
+      );
+    });
+  });
 });

--- a/packages/x402-client/tests/index.test.ts
+++ b/packages/x402-client/tests/index.test.ts
@@ -177,11 +177,10 @@ describe('x402-client', () => {
 
   describe('PaymentDetails.asset', () => {
     it('exposes the asset hex on the result so callers can label payments correctly', async () => {
-      // This is a structural assertion — it confirms the type carries `asset`
-      // and that fast.ts populates it from the server's payment requirement.
-      // We do NOT exercise the full Fast network flow (that's covered
-      // by integration tests). We do a minimal handler-level check by
-      // constructing a result via the public type and verifying TS accepts it.
+      // Structural / type-shape assertion only: confirms `PaymentDetails`
+      // carries an `asset` field that TS accepts as a string. This does NOT
+      // exercise fast.ts or evm.ts — the runtime population paths are covered
+      // by integration tests.
       const sample: import('../src/types.js').PaymentDetails = {
         network: 'fast-mainnet',
         amount: '1.0',

--- a/skills/fast/SKILL.md
+++ b/skills/fast/SKILL.md
@@ -82,8 +82,9 @@ Every supported subcommand is listed below. Use **exactly** these command names 
 
 | Command | Description | Key flags |
 |---|---|---|
-| `fast fund crypto <amount>` | Bridge USDC from an EVM chain into the Fast account | `--chain <chain>` (required), `--eip-7702` (gasless) |
-| `fast fund fiat` | Open a fiat on-ramp (mainnet only) | `--network mainnet` |
+| `fast fund usdc fiat` | Print a Ramp on-ramp URL for funding with USDC (mainnet only). Lands as **fastUSDC**. | `--network mainnet`, `--address` |
+| `fast fund usdc crypto <amount>` | Bridge USDC from an EVM chain into the Fast account. Lands as **fastUSDC**. | `--chain <chain>` (required), `--token`, `--eip-7702` (gasless) |
+| `fast fund fastusd` | Print an `app.fast.xyz/send` URL that opens the unified Fast funding page (mainnet only). Funds **fastUSD** (Fast-native, distinct from fastUSDC). | `--to <fast1...>`, `--amount <decimal>` |
 
 ### `send` command
 
@@ -95,7 +96,7 @@ fast send <address> <amount> [--token <TOKEN>] [--from-chain <chain>] [--to-chai
 |---|---|---|
 | `<address>` | Recipient address | `fast1...` (Fast network) or `0x...` (EVM) |
 | `<amount>` | Amount to send | numeric string, e.g. `"20"` |
-| `--token <TOKEN>` | Token to send (**always specify explicitly**) | `USDC` (default; `testUSDC` is an alias on testnet) |
+| `--token <TOKEN>` | Token to send. If omitted, defaults to `fastUSD` on mainnet (Fast→Fast) and `testUSDC` on testnet. | `USDC`, `fastUSDC`, `fastUSD`, `testUSDC` |
 | `--from-chain <chain>` | Bridge from this EVM chain into Fast | e.g. `arbitrum-sepolia`, `base` |
 | `--to-chain <chain>` | Bridge from Fast to this EVM chain | e.g. `arbitrum-sepolia` |
 | `--eip-7702` | Gasless deposit (no ETH needed on EVM side) | flag, no value |
@@ -169,7 +170,7 @@ the same Ed25519 key:
 - **EVM address** (`0x...`) — the same key expressed as an Ethereum address,
   used for bridge deposits
 
-When running `fast fund crypto` or `fast send --from-chain <chain>`, the CLI
+When running `fast fund usdc crypto` or `fast send --from-chain <chain>`, the CLI
 uses the EVM address derived from the current account's key. Use
 `fast account list` to see both addresses.
 
@@ -267,10 +268,10 @@ fast account set-default my-wallet # set 'my-wallet' as default
 fast send fast1ab2...y3w 10.5
 ```
 
-### 4. Fund from EVM → Fast (`fast fund crypto`)
+### 4. Fund from EVM → Fast (`fast fund usdc crypto`)
 
 ```sh
-fast fund crypto 50 --chain arbitrum-sepolia
+fast fund usdc crypto 50 --chain arbitrum-sepolia
 ```
 
 **What happens:**
@@ -285,7 +286,7 @@ fast fund crypto 50 --chain arbitrum-sepolia
 #### Gasless variant with EIP-7702 (no ETH needed)
 
 ```sh
-fast fund crypto 50 --chain base --eip-7702
+fast fund usdc crypto 50 --chain base --eip-7702
 ```
 
 Gas is paid in USDC instead of ETH. Approve + deposit are batched into a single
@@ -300,11 +301,23 @@ fast send 0xYourEvmAddress 25 --token USDC --to-chain arbitrum-sepolia
 ### 6. Fund via fiat (mainnet only)
 
 ```sh
-fast fund fiat --network mainnet
-# → prints an on-ramp URL
+fast fund usdc fiat --network mainnet
+# → prints a Ramp on-ramp URL (USDC → fastUSDC)
 ```
 
-### 7. Pay an x402-protected URL
+### 7. Fund fastUSD via the unified Fast web app
+
+```sh
+fast fund fastusd --network mainnet
+# → prints app.fast.xyz/send?to=<your-fast-address>
+fast fund fastusd --network mainnet --amount 25
+# → adds &amount=25
+```
+
+This URL is mainnet-only and funds **fastUSD** (a Fast-native token, separate
+from fastUSDC).
+
+### 8. Pay an x402-protected URL
 
 ```sh
 fast pay https://api.example.com/resource
@@ -327,11 +340,11 @@ derived from the **same private key**. You do not need a separate EVM wallet.
 When depositing via a bridge UI or another wallet, use the EVM address from
 `fast account list`.
 
-### `fast fund crypto` vs. `fast send --from-chain`
+### `fast fund usdc crypto` vs. `fast send --from-chain`
 
 | Command | Use when |
 |---|---|
-| `fast fund crypto <amount> --chain <chain>` | Top up your own Fast account from your own EVM balance |
+| `fast fund usdc crypto <amount> --chain <chain>` | Top up your own Fast account from your own EVM balance |
 | `fast send <fast-address> <amount> --from-chain <chain>` | Bridge from EVM to an arbitrary Fast recipient |
 
 ### Token names: `USDC` vs. `testUSDC`

--- a/skills/fast/SKILL.md
+++ b/skills/fast/SKILL.md
@@ -82,9 +82,9 @@ Every supported subcommand is listed below. Use **exactly** these command names 
 
 | Command | Description | Key flags |
 |---|---|---|
-| `fast fund usdc fiat` | Print a Ramp on-ramp URL for funding with USDC (mainnet only). Lands as **fastUSDC**. | `--network mainnet`, `--address` |
-| `fast fund usdc crypto <amount>` | Bridge USDC from an EVM chain into the Fast account. Lands as **fastUSDC**. | `--chain <chain>` (required), `--token`, `--eip-7702` (gasless) |
-| `fast fund fastusd` | Print an `app.fast.xyz/send` URL that opens the unified Fast funding page (mainnet only). Funds **fastUSD** (Fast-native, distinct from fastUSDC). | `--to <fast1...>`, `--amount <decimal>` |
+| `fast fund usdc fiat` | Print a Ramp on-ramp URL for funding with USDC (mainnet only). | `--network mainnet`, `--address` |
+| `fast fund usdc crypto <amount>` | Bridge USDC from an EVM chain into the Fast account. | `--chain <chain>` (required), `--token`, `--eip-7702` (gasless) |
+| `fast fund fastusd` | Print an `app.fast.xyz/send` URL that opens the unified Fast funding page (mainnet only). Funds **fastUSD** (Fast-native, distinct from bridged USDC). | `--to <fast1...>`, `--amount <decimal>` |
 
 ### `send` command
 
@@ -96,7 +96,7 @@ fast send <address> <amount> [--token <TOKEN>] [--from-chain <chain>] [--to-chai
 |---|---|---|
 | `<address>` | Recipient address | `fast1...` (Fast network) or `0x...` (EVM) |
 | `<amount>` | Amount to send | numeric string, e.g. `"20"` |
-| `--token <TOKEN>` | Token to send. If omitted, defaults to `fastUSD` on mainnet (Fast→Fast) and `testUSDC` on testnet. | `USDC`, `fastUSDC`, `fastUSD`, `testUSDC` |
+| `--token <TOKEN>` | Token to send. Route-specific defaults if omitted: Fast→Fast mainnet uses `fastUSD`; Fast→Fast testnet uses `testUSDC`; bridge routes use the chain's first configured token (typically `USDC`/`testUSDC`). | `USDC`, `fastUSD`, `testUSDC` |
 | `--from-chain <chain>` | Bridge from this EVM chain into Fast | e.g. `arbitrum-sepolia`, `base` |
 | `--to-chain <chain>` | Bridge from Fast to this EVM chain | e.g. `arbitrum-sepolia` |
 | `--eip-7702` | Gasless deposit (no ETH needed on EVM side) | flag, no value |
@@ -262,10 +262,14 @@ fast account delete old-wallet     # delete account named 'old-wallet' (NOT 'acc
 fast account set-default my-wallet # set 'my-wallet' as default
 ```
 
-### 3. Send USDC (Fast → Fast)
+### 3. Send tokens on Fast (Fast → Fast)
 
 ```sh
+# Default token: fastUSD on mainnet, testUSDC on testnet.
 fast send fast1ab2...y3w 10.5
+
+# To send USDC explicitly, pass --token:
+fast send fast1ab2...y3w 10.5 --token USDC
 ```
 
 ### 4. Fund from EVM → Fast (`fast fund usdc crypto`)
@@ -302,7 +306,7 @@ fast send 0xYourEvmAddress 25 --token USDC --to-chain arbitrum-sepolia
 
 ```sh
 fast fund usdc fiat --network mainnet
-# → prints a Ramp on-ramp URL (USDC → fastUSDC)
+# → prints a Ramp on-ramp URL for funding with USDC
 ```
 
 ### 7. Fund fastUSD via the unified Fast web app
@@ -315,7 +319,7 @@ fast fund fastusd --network mainnet --amount 25
 ```
 
 This URL is mainnet-only and funds **fastUSD** (a Fast-native token, separate
-from fastUSDC).
+from bridged USDC).
 
 ### 8. Pay an x402-protected URL
 


### PR DESCRIPTION
Two coordinated changes in `app/cli` plus light cosmetic fixes in `packages/x402-client`:

1. **`fund` command restructure.** Re-shape the `fund` subcommand group into a 2-deep tree:
   - `fast fund usdc fiat` (formerly `fund fiat`) — Ramp on-ramp URL → fastUSDC.
   - `fast fund usdc crypto <amount>` (formerly `fund crypto`) — allset bridge → fastUSDC.
   - **`fast fund fastusd`** (NEW) — emits `https://app.fast.xyz/send?to=<addr>&amount=<n>` for the unified Fast web app to fund **fastUSD** (a Fast-native token, distinct from fastUSDC). Mainnet only.
2. **fastUSD adoption.** `fastUSD` becomes the default Fast→Fast token in `send` on mainnet; testnet behavior is unchanged. New `fastTokens` map on the bundled mainnet network config carries the fastUSD token id. x402 payments stop mislabeling assets as `"USDC"` in display/log/history when the actual asset paid was something else.

Spec at `docs/superpowers/specs/2026-05-06-cli-fund-restructure-and-fastusd-design.md`. Plan at `docs/superpowers/plans/2026-05-06-cli-fund-restructure-and-fastusd.md`.

## What changed

**Schema + config:**
- `app/cli/src/schemas/networks.ts` — `NetworkConfigSchema` gains optional `fastTokens: Record<string, FastTokenConfig>`.
- `app/cli/src/config/networks.json` — mainnet gains `fastTokens.fastUSD` entry (token id `0x125b60bb…3a86eb`, decimals 6). Testnet unchanged.

**Token resolver** (`app/cli/src/services/token-resolver.ts`):
- `resolveToken` consults `fastTokens` first when no chain context is given.
- New `resolveDefaultToken(networkConfig)` — prefers `fastTokens.fastUSD`, falls back to single `fastTokens` entry, then first chain's first token.
- New `lookupTokenNameById(networkConfig, fastTokenId)` — inverse direction (id → name), case-insensitive and 0x-prefix-tolerant. Used by `pay.ts`.

**`send` Fast→Fast default** (`app/cli/src/commands/send.ts`, `send-token-helper.ts`):
- New `selectSendTokenName(explicit, networkConfig, chain)` helper. Mainnet defaults to fastUSD; testnet stays at testUSDC; explicit `--token` always wins; chain context (`--from-chain` / `--to-chain`) uses chain-scoped first token.

**x402 truth-in-display** (`packages/x402-client/src/types.ts`, `fast.ts`, `app/cli/src/commands/pay.ts`, `pay-asset-label.ts`):
- `PaymentDetails` gains optional `asset?: string`; `fast.ts` populates it from the server's payment requirement.
- New `labelAssetForPayment(networkConfig, asset)` helper translates the asset hex into a display name (or "unknown" / hex fallback). Used by `pay.ts` for both dry-run output and history records.
- Removed the misleading `"USDC"` literal from `pay.ts` (dry-run label, history `tokenName`) and `fast.ts` (verbose log line).

**Fund restructure** (`app/cli/src/cli.ts`, `main.ts`, `commands/index.ts`, `commands/fund/`):
- Optique parser tree: `fundGroup → or(fundUsdcGroup, fundFastUsdParser)` with `fundUsdcGroup → or(fiat, crypto)`.
- Old `fund/fiat.ts` and `fund/crypto.ts` moved under `fund/usdc/`. Handler/type/discriminant renames: `fundFiat` → `fundUsdcFiat`, `FundCryptoArgs` → `FundUsdcCryptoArgs`, `"fund-fiat"` → `"fund-usdc-fiat"`, etc.
- New `fund/fastusd.ts` handler + `fund/fastusd-url.ts` pure URL builder.
- `main.ts` `SUBCOMMANDS["fund"]` becomes `["usdc", "fastusd"]`; `SUBCOMMAND_REQUIREMENTS` rekeyed for 2-deep entries; parse-error post-processing extended to try a 3-deep key before falling back to 2-deep.

**Doc sync:** `skills/fast/SKILL.md`, `app/cli/README.md`, root `README.md`, `SPEC.md` — all updated to reflect the new command tree and fastUSD adoption.

**Test infrastructure:** `app/cli/vitest.config.ts` + `"test": "vitest run"` script. Tests live under `app/cli/tests/`. Mirrors the same shape as `feat/multisig-cli` (PR #85) — see "Conflicts" below.

## Test plan

- [x] `pnpm exec vitest run` from `app/cli/` — 31 pass (4 test files: token-resolver, send-default-token, pay-asset-label, fund-fastusd).
- [x] `pnpm exec vitest run` from `packages/x402-client/` — 20 pass.
- [x] `pnpm exec tsc --noEmit` clean: `app/cli`, `packages/x402-client`, `packages/fast-sdk`.
- [x] `pnpm build` (full monorepo turbo task) — green.
- [x] Manual smoke: `fast fund fastusd --help`, `fast fund usdc fiat --help`, `fast fund usdc crypto --help`, `fast fund usdc bogus 2>&1`, `fast fund usdc 2>&1`. All render expected docs and error messages.
- [x] Manual smoke: `fast fund fastusd --network mainnet --to fast1abc --amount 10` emits `https://app.fast.xyz/send?to=fast1abc&amount=10`.
- [x] Manual smoke: `fast fund fastusd --network testnet` errors with `InvalidUsageError: fastUSD funding is only available on mainnet…`.
- [ ] Smoke test against mainnet once the web app is live: open the emitted URL in a browser, confirm the page recognises `to=` and pre-fills `amount=`.
- [ ] Smoke test against testnet: `fast send fast1addr 5` (no `--token`) defaults to `testUSDC`.
- [ ] Smoke test against mainnet: `fast send fast1addr 5` (no `--token`) defaults to `fastUSD`.

## Conflicts to anticipate

- `feat/multisig-cli` (PR #85) also adds `app/cli/vitest.config.ts` and `"test": "vitest run"` to `app/cli/package.json`. Identical content on both sides — trivial conflict, will resolve cleanly.

## Out of scope (deferred)

- `x402-types`, `x402-facilitator`, `x402-server` — unchanged. Their `usdcAddress` / `usdcName` / `usdcVersion` fields are EVM-side EIP-3009 settlement concerns; fastUSD has no EVM counterpart.
- testnet fastUSD — does not exist; `fund fastusd` errors on testnet, `send` Fast→Fast default on testnet stays `testUSDC`.
- `parsePrice` regex stripping `/usdc/i` from price strings; `bridgeFastusdcToUsdc` rename in x402-client — cosmetic only, deferred.
- QR rendering / browser-launch for `fund fastusd` — terminals make URLs ctrl-clickable.
- Pre-existing typo in `skills/fast/SKILL.md` documenting `fast network add <file> --name <name>` (parser actually accepts `<name> --config <path>`). Out of scope for this branch — should be fixed separately.
- Handler-level Effect-runtime tests for `fund fastusd` (mainnet-only check, `--to` default to active account, etc.). Manual smoke covers these; introducing handler-level test scaffolding is disproportionate given no other CLI handler has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)