### PR TITLE
chore(sdk): switch mainnet defaultToken to fastUSD

### DIFF
--- a/.changeset/mainnet-default-token-fastusd.md
+++ b/.changeset/mainnet-default-token-fastusd.md
@@ -1,0 +1,5 @@
+---
+"@fastxyz/sdk": patch
+---
+
+Update `mainnet.defaultToken` to fastUSD (`0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb`, symbol `fastUSD`, 6 decimals). `testnet.defaultToken` is unchanged.

--- a/packages/fast-sdk/src/networks/mainnet.ts
+++ b/packages/fast-sdk/src/networks/mainnet.ts
@@ -5,8 +5,8 @@ export const mainnet = {
   explorerUrl: "https://explorer.fast.xyz",
   networkId: "fast:mainnet",
   defaultToken: {
-    tokenId: "0xc655a12330da6af361d281b197996d2bc135aaed3b66278e729c2222291e9130",
-    symbol: "USDC",
+    tokenId: "0x125b60bb2e805336f0934077d4f9fdb36f45bec9ded8d7b0e637516cc43a86eb",
+    symbol: "fastUSD",
     decimals: 6,
   },
 } satisfies FastNetwork;

--- a/packages/fast-sdk/src/networks/types.ts
+++ b/packages/fast-sdk/src/networks/types.ts
@@ -4,7 +4,7 @@ import type { NetworkId } from "@fastxyz/schema";
 export interface FastToken {
   /** Token identifier (hex), e.g. `"0xc655a1..."`. */
   tokenId: string;
-  /** Token symbol, e.g. `"USDC"`. */
+  /** Token symbol, e.g. `"fastUSD"`. */
   symbol: string;
   /** Number of decimal places. */
   decimals: number;
@@ -18,6 +18,6 @@ export interface FastNetwork {
   explorerUrl?: string;
   /** Network identifier, e.g. `"fast:mainnet"`. */
   networkId?: NetworkId;
-  /** Default token for this network (e.g. USDC on mainnet, testUSDC on testnet). */
+  /** Default token for this network (e.g. fastUSD on mainnet, testUSDC on testnet). */
   defaultToken?: FastToken;
 }


### PR DESCRIPTION
Replace `mainnet.defaultToken` from USDC (`0xc655a123…2291e9130`) to fastUSD (`0x125b60bb…3a86eb`), keeping decimals at 6. `testnet.defaultToken` is unchanged.

Also refreshes the `FastToken`/`FastNetwork` doc-comment examples to reference fastUSD on mainnet.

## Verification
- `packages/fast-sdk` typecheck: no new errors introduced (pre-existing `envelope.ts` error is unrelated)
- Patch changeset added for `@fastxyz/sdk`